### PR TITLE
 Adding support for excluding fields based on custom annotations 

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -78,6 +78,8 @@ public class PodamFactoryImpl implements PodamFactory {
 	 * </p>
 	 */
 	private final DataProviderStrategy strategy;
+	
+	private List<Class<? extends Annotation>> excludeAnnotations;
 
 	// ------------------->> Constructors
 
@@ -1294,7 +1296,7 @@ public class PodamFactoryImpl implements PodamFactory {
 				return null;
 			}
 
-			ClassInfo classInfo = PodamUtils.getClassInfo(pojoClass);
+			ClassInfo classInfo = PodamUtils.getClassInfo(pojoClass, excludeAnnotations);
 
 			if (classInfo.getClassSetters().isEmpty()) {
 
@@ -2928,6 +2930,21 @@ public class PodamFactoryImpl implements PodamFactory {
 
 		return retValue;
 
+	}
+
+	/**
+	 * @return the excludeAnnotations
+	 */
+	public List<Class<? extends Annotation>> getExcludeAnnotations() {
+		return excludeAnnotations;
+	}
+
+	/**
+	 * @param excludeAnnotations the excludeAnnotations to set
+	 */
+	public void setExcludeAnnotations(
+			List<Class<? extends Annotation>> excludeAnnotations) {
+		this.excludeAnnotations = excludeAnnotations;
 	}
 
 	// ------------------->> equals() / hashcode() / toString()

--- a/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
@@ -3,8 +3,11 @@
  */
 package uk.co.jemos.podam.test.unit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import junit.framework.Assert;
@@ -14,6 +17,8 @@ import org.junit.Test;
 import uk.co.jemos.podam.dto.ClassInfo;
 import uk.co.jemos.podam.test.dto.EmptyTestPojo;
 import uk.co.jemos.podam.test.dto.SimplePojoToTestSetters;
+import uk.co.jemos.podam.test.dto.SimplePojoWithExcludeAnnotationToTestSetters;
+import uk.co.jemos.podam.test.dto.SimplePojoWithExcludeAnnotationToTestSetters.TestExclude;
 import uk.co.jemos.podam.utils.PodamUtils;
 
 /**
@@ -61,6 +66,22 @@ public class ClassInfoUnitTest {
 				"The expected and actual ClassInfo objects do not match!",
 				expectedClassInfo, actualClassInfo);
 
+	}
+	
+	@Test
+	public void testClassInfoWithExcludeAnnotations() {
+		Set<String> pojoFields = new HashSet<String>();
+		pojoFields.add("stringField");
+		pojoFields.add("intField");
+
+		Set<Method> pojoSetters = PodamUtils.getPojoSetters(SimplePojoWithExcludeAnnotationToTestSetters.class, pojoFields);
+
+		ClassInfo expectedClassInfo = new ClassInfo(SimplePojoWithExcludeAnnotationToTestSetters.class, pojoFields, pojoSetters);
+		List<Class<? extends Annotation>> excludeAnnotations = new ArrayList<Class<? extends Annotation>>();
+		excludeAnnotations.add(TestExclude.class);
+		ClassInfo actualClassInfo = PodamUtils.getClassInfo(SimplePojoWithExcludeAnnotationToTestSetters.class, excludeAnnotations);
+		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
+		Assert.assertEquals("The expected and actual ClassInfo objects do not match!", expectedClassInfo, actualClassInfo);
 	}
 
 	// ------------------------------> Private methods


### PR DESCRIPTION
The PodamExclude annotation allows excluding the fields. But that would create tight coupling with the application classes. This change will allow excluding fields with custom annotations like jackson @JsonIgnore, jpa @Transient annotations etc..  
