### PR TITLE
Test for class with generic type

### DIFF
--- a/src/test/java/uk/co/jemos/podam/test/dto/pdm3/Pdm3PojoConstructor.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/pdm3/Pdm3PojoConstructor.java
@@ -1,0 +1,27 @@
+package uk.co.jemos.podam.test.dto.pdm3;
+
+import java.util.List;
+
+/**
+ * Pojo to test <a href="https://agileguru.atlassian.net/browse/PDM-3">PDM-3</a>
+ * 
+ * @author daivanov
+ * 
+ */
+public class Pdm3PojoConstructor<T extends String> {
+
+	private T name;
+
+	public Pdm3PojoConstructor(T name) {
+		this.name = name;
+	}
+
+	public T getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("{name: '%s'}", name);
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 import uk.co.jemos.podam.test.dto.pdm3.Pdm3Pojo;
+import uk.co.jemos.podam.test.dto.pdm3.Pdm3PojoConstructor;
 import uk.co.jemos.podam.test.dto.pdm3.Pdm3PojoGenericsConstructor;
 
 /**
@@ -29,6 +30,15 @@ public class Pdm3PojoUnitTest {
 		assertCollection(pojo.getSomething());
 		assertCollection(pojo.getDescendants());
 		assertCollection(pojo.getAncestors());
+	}
+
+	@Test
+	public void testPdm3PojoConstructor() {
+
+		PodamFactory factory = new PodamFactoryImpl();
+		Pdm3PojoConstructor pojo = factory.manufacturePojo(Pdm3PojoConstructor.class, String.class);
+		assertNotNull(pojo);
+		assertNotNull(pojo.getName());
 	}
 
 	@Test


### PR DESCRIPTION
It seems that this code:
List<SomeObject.class> pojos = factory.manufacturePojo(ArrayList.class, SomeObject.class);
results in empty list, when executed in Java 6, and in properly filled list, when executed in Java 7.
This is unrelated to my latest pull request(s). I will try to make a separate fix for that: to make Java 6 code produce the same result as Java 7.
This is just another test for class with generic type.
