### PR TITLE
Removing unnecessary branch in execution, which is handled by the following code

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -452,12 +452,12 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			}
 
-			if (retValue == null) {
-				LOG.warn("For class: " + clazz.getName()
-						+ " PODAM could not possibly create a value."
-						+ " This attribute will be returned as null.");
-			}
+		}
 
+		if (retValue == null) {
+			LOG.warn("For class: " + clazz.getName()
+					+ " PODAM could not possibly create a value."
+					+ " This attribute will be returned as null.");
 		}
 
 		return retValue;
@@ -1364,15 +1364,6 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			ClassInfo classInfo = PodamUtils.getClassInfo(pojoClass,
 					excludeAnnotations);
-
-			if (classInfo.getClassSetters().isEmpty()) {
-
-				// A rudimentary attempt to manage immutable classes (e.g. with
-				// constructor only and final fields - no setters)
-				return this.resolvePojoWithoutSetters(pojoClass, depth,
-						genericTypeArgs);
-
-			}
 
 			// If a public no-arg constructor can be found we use it,
 			// otherwise we try to find a non-public one and we use that. If the

--- a/src/test/java/uk/co/jemos/podam/test/dto/pdm5/InvisibleConstructorAndNoSettersPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/pdm5/InvisibleConstructorAndNoSettersPojo.java
@@ -1,0 +1,25 @@
+package uk.co.jemos.podam.test.dto.pdm5;
+
+/**
+ * Pojo to test invisible constructor
+ * 
+ * @author divanov
+ * 
+ */
+public class InvisibleConstructorAndNoSettersPojo {
+
+	private String value;
+
+	InvisibleConstructorAndNoSettersPojo(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("{value: '%s'}", value);
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/pdm5/InvisibleConstructorAndNoSettersTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/pdm5/InvisibleConstructorAndNoSettersTest.java
@@ -1,0 +1,28 @@
+/**
+ * Test multiple constructors with setters
+ */
+package uk.co.jemos.podam.test.unit.pdm5;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.pdm5.InvisibleConstructorAndNoSettersPojo;
+
+/**
+ * @author divanov
+ *
+ */
+public class InvisibleConstructorAndNoSettersTest {
+
+	@Test
+	public void testInvisibleConstructorAndNoSetters() {
+
+		PodamFactory factory = new PodamFactoryImpl();
+		InvisibleConstructorAndNoSettersPojo pojo = factory.manufacturePojo(
+				InvisibleConstructorAndNoSettersPojo.class);
+		assertNotNull(pojo);
+	}
+}


### PR DESCRIPTION
This patch fixes difference in producing POJOs with non-public constructor and no setters and POJOs with non-public constructor and setters.
