### PR TITLE
Add support for externally registered factories

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
@@ -69,4 +69,5 @@ public interface PodamFactory {
 	 */
 	public DataProviderStrategy getStrategy();
 
+	void registerFactory(Class attributeClass, AttributeStrategy podamOptional);
 }

--- a/src/test/java/uk/co/jemos/podam/test/strategies/ExternalStrategy.java
+++ b/src/test/java/uk/co/jemos/podam/test/strategies/ExternalStrategy.java
@@ -1,0 +1,48 @@
+package uk.co.jemos.podam.test.strategies;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+import uk.co.jemos.podam.api.AttributeStrategy;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+/**
+ * Tests for externally registered strategies.
+ */
+public class ExternalStrategy {
+
+	@Test
+	public void externalStrategyTest() {
+		PodamFactory factory = new PodamFactoryImpl();
+
+		MyFactory myFactory = new MyFactory();
+		factory.registerFactory(MyCustomClass.class, myFactory);
+
+		MyClass storedModuleDto = factory.manufacturePojo(MyClass.class);
+		Assert.assertNotNull(storedModuleDto);
+		Assert.assertNotNull(storedModuleDto.customClass);
+	}
+
+	public class MyFactory implements AttributeStrategy<MyCustomClass> {
+
+		public MyCustomClass getValue() throws PodamMockeryException {
+			return new MyCustomClass();
+		}
+	}
+
+	public class MyClass {
+
+		public MyClass(MyCustomClass customClass) {
+			this.customClass = customClass;
+		}
+
+		public MyCustomClass customClass;
+	}
+
+	public class MyCustomClass {
+
+	}
+
+}


### PR DESCRIPTION
Useful when you can't, or don't want to modify the
classes you're hydrating.