### PR TITLE
Fix false warning about setters being non-public

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1572,13 +1572,13 @@ public class PodamFactoryImpl implements PodamFactory {
 				// the sake of
 				// usability. However this violates Javabean standards and
 				// it's a security hack
-				if (!setter.isAccessible()) {
+				if (!Modifier.isPublic(setter.getModifiers())) {
 					LOG.warn(
-							"The setter: {} is not accessible.Setting it to accessible. "
-									+ "However this is a security hack and your code should really adhere to Javabean standards.",
-							setter.getName());
-					setter.setAccessible(true);
+							"The setter: {} is not public. Setting it to accessible. "
+										+ "However this is a security hack and your code should really adhere to Javabean standards.",
+						setter.getName());
 				}
+				setter.setAccessible(true);
 				setter.invoke(retValue, setterArg);
 			} else {
 				LOG.warn("Couldn't find a suitable value for attribute: {}"

--- a/src/test/java/uk/co/jemos/podam/test/unit/PrivateSetterPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/PrivateSetterPojo.java
@@ -1,0 +1,16 @@
+package uk.co.jemos.podam.test.unit;
+
+public class PrivateSetterPojo {
+	private int value;
+	
+	public PrivateSetterPojo() {
+	}
+	
+	public int getValue() {
+		return value;
+	}
+	
+	private void setValue(int value) {
+		this.value = value;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/PrivateSetterPojoTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/PrivateSetterPojoTest.java
@@ -1,0 +1,16 @@
+package uk.co.jemos.podam.test.unit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+public class PrivateSetterPojoTest {
+	@Test
+	public void testPrivateAccessors() {
+		PodamFactory factory = new PodamFactoryImpl();
+		PrivateSetterPojo pojo = factory.manufacturePojo(PrivateSetterPojo.class);
+		Assert.assertNotNull(pojo);
+		Assert.assertNotNull(pojo.getValue());
+	}
+}


### PR DESCRIPTION
The accessible flag specifies whether or not the usual java access
checks are going to be ignored for this method, not whether the
method is accessible to the caller.

This flag starts out as false, so all setters were being flagged as
incorrect. Instead, use the modifiers to check whether or not the
setter is actually public.
