### PR TITLE
Sort static factory methods to ensure deterministic order. Is it good idea or not?

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
@@ -5,6 +5,7 @@ package uk.co.jemos.podam.api;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,6 +14,7 @@ import java.util.Set;
 import java.util.Random;
 
 import uk.co.jemos.podam.common.ConstructorComparator;
+import uk.co.jemos.podam.common.MethodComparator;
 import uk.co.jemos.podam.common.PodamConstants;
 
 /**
@@ -42,6 +44,9 @@ public abstract class AbstractRandomDataProviderStrategy implements DataProvider
 
 	/** The constructor comparator */
 	private static final ConstructorComparator CONSTRUCTOR_COMPARATOR = new ConstructorComparator();
+
+	/** The constructor comparator */
+	private static final MethodComparator METHOD_COMPARATOR = new MethodComparator();
 
 	/** An array of valid String characters */
 	public static final char[] NICE_ASCII_CHARACTERS = new char[] { 'a', 'b',
@@ -446,6 +451,19 @@ public abstract class AbstractRandomDataProviderStrategy implements DataProvider
 	}
 
 	/**
+	 * Rearranges POJO's methods in order they will be tried to produce the
+	 * POJO. Default strategy consist of putting methods with more
+	 * parameters to be tried first.
+	 *
+	 * @param methods
+	 *            Array of POJO's methods
+	 */
+	@Override
+	public void sort(Method[] methods) {
+		Arrays.sort(methods, METHOD_COMPARATOR);
+	}
+
+	/**
 	 * Bind an interface/abstract class to a specific implementation
 	 *
 	 * @param abstractClass
@@ -481,6 +499,7 @@ public abstract class AbstractRandomDataProviderStrategy implements DataProvider
 	@Override
 	public <T> Class<? extends T> getSpecificClass(
 			Class<T> nonInstantiatableClass) {
+		@SuppressWarnings("unchecked")
 		Class<? extends T> found = (Class<? extends T>) specificTypes
 				.get(nonInstantiatableClass);
 		if (found == null) {

--- a/src/main/java/uk/co/jemos/podam/api/DataProviderStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/DataProviderStrategy.java
@@ -5,6 +5,7 @@ package uk.co.jemos.podam.api;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.util.Set;
 
 /**
@@ -197,6 +198,17 @@ public interface DataProviderStrategy {
 	 *            Array of POJO's constructors
 	 */
 	void sort(Constructor<?>[] constructors);
+
+	/**
+	 * Rearranges POJO's methods in order they will be tried to
+	 * produce the POJO.
+	 * Default strategy consists of putting factory methods with more parameters
+	 * to be tried first.
+	 * 
+	 * @param methods
+	 *            Array of POJO's methods
+	 */
+	void sort(Method[] methods);
 
 	/**
 	 * Resolves abstract classes and interfaces.

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -331,6 +331,7 @@ public class PodamFactoryImpl implements PodamFactory {
 			// getInstance())
 
 			Method[] declaredMethods = clazz.getDeclaredMethods();
+			strategy.sort(declaredMethods);
 
 			// A candidate factory method is a method which returns the
 			// Class type

--- a/src/main/java/uk/co/jemos/podam/common/MethodComparator.java
+++ b/src/main/java/uk/co/jemos/podam/common/MethodComparator.java
@@ -1,0 +1,37 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.common;
+
+import java.lang.reflect.Method;
+import java.util.Comparator;
+
+/**
+ * It provides a comparator to sort the constructor to choose first.
+ * <p>
+ * The priority goes to constructors with the {@link PodamConstructor}
+ * annotation first, and then to those with more arguments.
+ * </p>
+ * 
+ * @author tedonema
+ *
+ */
+public class MethodComparator implements Comparator<Method> {
+
+	@Override
+	public int compare(Method method1, Method method2) {
+		/* Constructors with Podam annotation first */
+		boolean choose1 = method1.getAnnotation(PodamConstructor.class) != null;
+		boolean choose2 = method2.getAnnotation(PodamConstructor.class) != null;
+		if (choose1 && !choose2) {
+			return Integer.MIN_VALUE;
+		} else if (!choose1 && choose2) {
+			return Integer.MAX_VALUE;
+		}
+
+		/* Then constructors with more parameters */
+		return method2.getParameterTypes().length
+				- method1.getParameterTypes().length;
+	}
+
+}


### PR DESCRIPTION
While checking Issue #23 I noticed that sometimes PODAM creates pojo with `Optional.absent()` and sometimes with `Optional.fromNullable(T nullableReference)`. This results in very different objects, the former has no object inside and the latter has it. This is the same issue as with constructors, which are returned in non-fixed order.

I actually would prefer Optional to be created with reference inside, but I cannot see how PODAM would potentially know that `Optional.fromNullable(T nullableReference)` is better factory method comparing to `Optional.absent()`.