### PR TITLE
Making getDefaultFieldValue() safe and efficient

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/AbstractMapArguments.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractMapArguments.java
@@ -12,27 +12,10 @@ import java.util.Map;
  */
 public abstract class AbstractMapArguments {
 
-	/** The POJO where the Map attribute has been declared. */
-	private Class<?> pojoClass;
 	/** Set of manufactured pojos' types. */
 	private Map<Class<?>, Integer> pojos;
 	/** The annotations for the attribute. */
 	private List<Annotation> annotations;
-
-	/**
-	 * @return the pojoClass
-	 */
-	public Class<?> getPojoClass() {
-		return pojoClass;
-	}
-
-	/**
-	 * @param pojoClass
-	 *            the pojoClass to set
-	 */
-	public void setPojoClass(Class<?> pojoClass) {
-		this.pojoClass = pojoClass;
-	}
 
 	/**
 	 * @return the pojos
@@ -70,9 +53,7 @@ public abstract class AbstractMapArguments {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("AbstractMapArguments [pojoClass=");
-		builder.append(pojoClass);
-		builder.append(", pojos=");
+		builder.append("AbstractMapArguments [pojos=");
 		builder.append(pojos);
 		builder.append(", annotations=");
 		builder.append(annotations);

--- a/src/main/java/uk/co/jemos/podam/api/MapKeyOrElementsArguments.java
+++ b/src/main/java/uk/co/jemos/podam/api/MapKeyOrElementsArguments.java
@@ -3,6 +3,7 @@ package uk.co.jemos.podam.api;
 import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Map;
 
 import uk.co.jemos.podam.common.AttributeStrategy;
 
@@ -18,6 +19,9 @@ public class MapKeyOrElementsArguments extends AbstractMapArguments implements
 
 	private static final long serialVersionUID = 1L;
 
+	/** The Map type. */
+	private Class<? extends Map<?, ?>> pojoClass;
+
 	/** The Map key / element type. */
 	private Class<?> keyOrValueType;
 
@@ -29,6 +33,21 @@ public class MapKeyOrElementsArguments extends AbstractMapArguments implements
 	 * instance.
 	 */
 	private Type[] genericTypeArgs;
+
+	/**
+	 * @param pojoClass
+	 *            the pojoClass to set
+	 */
+	public void setPojoClass(Class<? extends Map<?, ?>> pojoClass) {
+		this.pojoClass = pojoClass;
+	}
+
+	/**
+	 * @return the keyOrValueType
+	 */
+	public Class<? extends Map<?,?>> getPojoClass() {
+		return pojoClass;
+	}
 
 	/**
 	 * @return the keyOrValueType
@@ -92,5 +111,4 @@ public class MapKeyOrElementsArguments extends AbstractMapArguments implements
 		builder.append("]");
 		return builder.toString();
 	}
-
 }

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -2132,7 +2132,7 @@ public class PodamFactoryImpl implements PodamFactory {
 						typeArgsMap, elementGenericTypeArgs);
 			}
 
-			fillCollection(pojoClass, pojos, annotations, retValue, typeClass,
+			fillCollection(pojos, annotations, retValue, typeClass,
 					elementGenericTypeArgs.get());
 
 		} catch (SecurityException e) {
@@ -2191,16 +2191,15 @@ public class PodamFactoryImpl implements PodamFactory {
 			InvocationTargetException, ClassNotFoundException {
 
 		final Map<String, Type> typeArgsMap = new HashMap<String, Type>();
-		Class<?> pojoClass = collection.getClass();
+		Class<?> collectionClass = collection.getClass();
 		Type[] genericTypeArgsExtra = fillTypeArgMap(typeArgsMap,
-				pojoClass, genericTypeArgs);
+				collectionClass, genericTypeArgs);
 		if (genericTypeArgsExtra != null && genericTypeArgsExtra.length > 0) {
 			LOG.warn("Lost generic type arguments {}",
 					Arrays.toString(genericTypeArgsExtra));
 		}
 
 		Annotation[] annotations = collection.getClass().getAnnotations();
-		Class<?> collectionClass = pojoClass;
 		AtomicReference<Type[]> elementGenericTypeArgs = new AtomicReference<Type[]>(
 				new Type[] {});
 		Type[] typeParams = collectionClass.getTypeParameters();
@@ -2212,7 +2211,7 @@ public class PodamFactoryImpl implements PodamFactory {
 		}
 		Class<?> elementTypeClass = resolveGenericParameter(typeParams[0],
 					typeArgsMap, elementGenericTypeArgs);
-		fillCollection(pojoClass, pojos, Arrays.asList(annotations),
+		fillCollection(pojos, Arrays.asList(annotations),
 				collection, elementTypeClass, elementGenericTypeArgs.get());
 	}
 
@@ -2225,8 +2224,6 @@ public class PodamFactoryImpl implements PodamFactory {
 	 * as argument.
 	 * </p>
 	 *
-	 * @param pojoClass
-	 *            The POJO where the collection attribute is defined
 	 * @param pojos
 	 *            Set of manufactured pojos' types
 	 * @param annotations
@@ -2249,9 +2246,8 @@ public class PodamFactoryImpl implements PodamFactory {
 	 *             If it was not possible to create a class from a string
 	 *
 	 */
-	private void fillCollection(Class<?> pojoClass,
-			Map<Class<?>, Integer> pojos, List<Annotation> annotations,
-			Collection<? super Object> collection,
+	private void fillCollection(Map<Class<?>, Integer> pojos,
+			List<Annotation> annotations, Collection<? super Object> collection,
 			Class<?> collectionElementType, Type... genericTypeArgs)
 			throws InstantiationException, IllegalAccessException,
 			InvocationTargetException, ClassNotFoundException {
@@ -2305,7 +2301,7 @@ public class PodamFactoryImpl implements PodamFactory {
 						collectionElementType, elementStrategy);
 			} else {
 				String elementAttributeName = null;
-				element = manufactureAttributeValue(pojoClass, pojos,
+				element = manufactureAttributeValue(collection.getClass(), pojos,
 						collectionElementType, annotations, elementAttributeName,
 						genericTypeArgs);
 			}
@@ -2397,7 +2393,6 @@ public class PodamFactoryImpl implements PodamFactory {
 			}
 
 			MapArguments mapArguments = new MapArguments();
-			mapArguments.setPojoClass(pojoClass);
 			mapArguments.setPojos(pojos);
 			mapArguments.setAnnotations(annotations);
 			mapArguments.setMapToBeFilled(retValue);
@@ -2480,7 +2475,6 @@ public class PodamFactoryImpl implements PodamFactory {
 		Class<?> elementClass = resolveGenericParameter(typeParams[1],
 					typeArgsMap, elementGenericTypeArgs);
 		MapArguments mapArguments = new MapArguments();
-		mapArguments.setPojoClass(pojoClass);
 		mapArguments.setPojos(pojos);
 		mapArguments.setAnnotations(Arrays.asList(pojoClass.getAnnotations()));
 		mapArguments.setMapToBeFilled(map);
@@ -2557,8 +2551,12 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			Object elementValue = null;
 
+			@SuppressWarnings("unchecked")
+			Class<? extends Map<?, ?>> mapType =
+					(Class<? extends Map<?, ?>>) mapArguments.getMapToBeFilled().getClass();
+
 			MapKeyOrElementsArguments valueArguments = new MapKeyOrElementsArguments();
-			valueArguments.setPojoClass(mapArguments.getPojoClass());
+			valueArguments.setPojoClass(mapType);
 			valueArguments.setPojos(mapArguments.getPojos());
 			valueArguments.setAnnotations(mapArguments.getAnnotations());
 			valueArguments.setKeyOrValueType(mapArguments.getKeyClass());
@@ -2569,7 +2567,7 @@ public class PodamFactoryImpl implements PodamFactory {
 			keyValue = getMapKeyOrElementValue(valueArguments);
 
 			valueArguments = new MapKeyOrElementsArguments();
-			valueArguments.setPojoClass(mapArguments.getPojoClass());
+			valueArguments.setPojoClass(mapType);
 			valueArguments.setPojos(mapArguments.getPojos());
 			valueArguments.setAnnotations(mapArguments.getAnnotations());
 			valueArguments.setKeyOrValueType(mapArguments.getElementClass());
@@ -2934,7 +2932,7 @@ public class PodamFactoryImpl implements PodamFactory {
 
 				Type[] genericTypeArgsAll = mergeTypeArrays(
 						collectionGenericTypeArgs.get(), genericTypeArgsExtra);
-				fillCollection(pojoClass, pojos, annotations,
+				fillCollection(pojos, annotations,
 						collection, collectionElementType, genericTypeArgsAll);
 
 				parameterValues[idx] = collection;
@@ -2972,7 +2970,6 @@ public class PodamFactoryImpl implements PodamFactory {
 						elementGenericTypeArgs.get(), genericTypeArgsExtra);
 
 				MapArguments mapArguments = new MapArguments();
-				mapArguments.setPojoClass(pojoClass);
 				mapArguments.setPojos(pojos);
 				mapArguments.setAnnotations(annotations);
 				mapArguments.setMapToBeFilled(mapType);

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -376,8 +376,6 @@ public class PodamFactoryImpl implements PodamFactory {
 						List<Annotation> annotations = Arrays
 								.asList(parameterAnnotations[idx]);
 
-						String attributeName = null;
-
 						// It's a Collection type
 						if (Collection.class.isAssignableFrom(parameterType)) {
 
@@ -409,9 +407,8 @@ public class PodamFactoryImpl implements PodamFactory {
 							}
 
 							for (int i = 0; i < nbrElements; i++) {
-								Object attributeValue = manufactureAttributeValue(
-										clazz, pojos, elementType, annotations,
-										attributeName);
+								Object attributeValue = manufactureParameterValue(
+										pojos, elementType, annotations);
 
 								listType.add(attributeValue);
 							}
@@ -453,13 +450,11 @@ public class PodamFactoryImpl implements PodamFactory {
 							}
 
 							for (int i = 0; i < nbrElements; i++) {
-								Object keyValue = manufactureAttributeValue(
-										clazz, pojos, keyClass, annotations,
-										attributeName);
+								Object keyValue = manufactureParameterValue(
+										pojos, keyClass, annotations);
 
-								Object elementValue = manufactureAttributeValue(
-										clazz, pojos, valueClass, annotations,
-										attributeName);
+								Object elementValue = manufactureParameterValue(
+										pojos, valueClass, annotations);
 
 								mapType.put(keyValue, elementValue);
 							}
@@ -469,9 +464,9 @@ public class PodamFactoryImpl implements PodamFactory {
 						} else {
 
 							// It's any other object
-							parameterValues[idx] = manufactureAttributeValue(
-									clazz, pojos, parameterType, annotations,
-									attributeName, typeArgsMap, genericTypeArgs);
+							parameterValues[idx] = manufactureParameterValue(
+									pojos, parameterType, annotations,
+									genericTypeArgs);
 
 						}
 
@@ -1626,24 +1621,20 @@ public class PodamFactoryImpl implements PodamFactory {
 	}
 
 	/**
-	 * It manufactures and returns the value for a POJO attribute.
+	 * It manufactures and returns the value for a POJO method parameter.
 	 *
 	 *
-	 * @param pojoClass
-	 *            The POJO class being filled with values
 	 * @param pojos
 	 *            Set of manufactured pojos' types
-	 * @param attributeType
+	 * @param parameterType
 	 *            The type of the attribute for which a value is being
 	 *            manufactured
 	 * @param annotations
 	 *            The annotations for the attribute being considered
-	 * @param attributeName
-	 *            The attribute name
 	 * @param genericTypeArgs
 	 *            The generic type arguments for the current generic class
 	 *            instance
-	 * @return The value for an attribute
+	 * @return The value for a parameter
 	 *
 	 * @throws InstantiationException
 	 *             If an exception occurred during instantiation
@@ -1663,16 +1654,16 @@ public class PodamFactoryImpl implements PodamFactory {
 	 *             </ul>
 	 *
 	 */
-	private Object manufactureAttributeValue(Class<?> pojoClass,
-			Map<Class<?>, Integer> pojos, Class<?> attributeType,
-			List<Annotation> annotations, String attributeName,
+	private Object manufactureParameterValue(Map<Class<?>, Integer> pojos,
+			Class<?> parameterType, List<Annotation> annotations,
 			Type... genericTypeArgs) throws InstantiationException,
 			IllegalAccessException, InvocationTargetException,
 			ClassNotFoundException {
 
 		Map<String, Type> nullTypeArgsMap = new HashMap<String, Type>();
+		String attributeName = null;
 
-		return manufactureAttributeValue(pojoClass, pojos, attributeType,
+		return manufactureAttributeValue(Object.class, pojos, parameterType,
 				annotations, attributeName, nullTypeArgsMap, genericTypeArgs);
 	}
 
@@ -2314,10 +2305,8 @@ public class PodamFactoryImpl implements PodamFactory {
 				element = returnAttributeDataStrategyValue(
 						collectionElementType, elementStrategy);
 			} else {
-				String elementAttributeName = null;
-				element = manufactureAttributeValue(collection.getClass(), pojos,
-						collectionElementType, annotations, elementAttributeName,
-						genericTypeArgs);
+				element = manufactureParameterValue(pojos,
+						collectionElementType, annotations, genericTypeArgs);
 			}
 			collection.add(element);
 		}
@@ -2646,13 +2635,10 @@ public class PodamFactoryImpl implements PodamFactory {
 
 		} else {
 
-			String keyOrElementAttributeName = null;
-			retValue = manufactureAttributeValue(
-					keyOrElementsArguments.getPojoClass(),
+			retValue = manufactureParameterValue(
 					keyOrElementsArguments.getPojos(),
 					keyOrElementsArguments.getKeyOrValueType(),
 					keyOrElementsArguments.getAnnotations(),
-					keyOrElementAttributeName,
 					keyOrElementsArguments.getGenericTypeArgs());
 		}
 		return retValue;
@@ -2920,8 +2906,6 @@ public class PodamFactoryImpl implements PodamFactory {
 			List<Annotation> annotations = Arrays
 					.asList(parameterAnnotations[idx]);
 
-			String attributeName = null;
-
 			if (Collection.class.isAssignableFrom(parameterType)) {
 
 				Collection<? super Object> collection = resolveCollectionType(parameterType);
@@ -2998,9 +2982,8 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			} else {
 
-				parameterValues[idx] = manufactureAttributeValue(pojoClass,
-						pojos, parameterType, annotations, attributeName,
-						typeArgsMap, genericTypeArgs);
+				parameterValues[idx] = manufactureParameterValue(pojos,
+						parameterType, annotations, genericTypeArgs);
 
 			}
 

--- a/src/test/java/uk/co/jemos/podam/test/dto/DefaultFieldPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/DefaultFieldPojo.java
@@ -1,0 +1,27 @@
+package uk.co.jemos.podam.test.dto;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Pojo with default field
+ *
+ * @author daivanov
+ *
+ */
+public class DefaultFieldPojo<K,V> {
+
+	private Map<K,V> map = new TreeMap<K,V>();
+
+	public DefaultFieldPojo(K key) {
+		map.remove(key);
+	}
+
+	public Map<K,V> getMap() {
+		return map;
+	}
+
+	public void setMap(Map<K,V> map) {
+		this.map = map;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/DefaultFieldUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/DefaultFieldUnitTest.java
@@ -1,0 +1,40 @@
+package uk.co.jemos.podam.test.unit;
+
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.DefaultFieldPojo;
+
+/**
+ * Test @uk.co.jemos.podam.test.dto.JAXBElementPojo@ construction
+ *
+ * @author daivanov
+ *
+ */
+public class DefaultFieldUnitTest {
+
+	private final static PodamFactory podam = new PodamFactoryImpl();
+
+	@Test
+	public void testDefaultFieldPojo() throws Exception {
+	
+		DefaultFieldPojo<?,?> pojo = podam.manufacturePojo(
+				DefaultFieldPojo.class, String.class, Long.class);
+		Assert.assertNotNull("Construction failed", pojo);
+		Assert.assertNotNull("Field setting failed", pojo.getMap());
+		Assert.assertEquals("Wrong type of field",
+				TreeMap.class, pojo.getMap().getClass());
+		for (Entry<?, ?> entry : pojo.getMap().entrySet()) {
+			Assert.assertEquals("Wrong type of field's key",
+					String.class, entry.getKey().getClass());
+			Assert.assertEquals("Wrong type of field's key",
+					Long.class, entry.getValue().getClass());
+		}
+	}
+
+}


### PR DESCRIPTION
getDefaultFieldValue() is not safe, as it tries to create POJO with no argument constructor to get default value of attribute. Such constructor might not exist and anyway we already have POJO instantiated at this stage of production, so this is a performance issue.

    java.lang.InstantiationException: uk.co.jemos.podam.test.dto.pdm45.MultiDimensionalConstructorPojo
    	at java.lang.Class.newInstance(Class.java:359)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.getDefaultFieldValue(PodamFactoryImpl.java:1932)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.resolveCollectionValueWhenCollectionIsPojoAttribute(PodamFactoryImpl.java:2106)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.manufactureAttributeValue(PodamFactoryImpl.java:1769)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.manufacturePojoInternal(PodamFactoryImpl.java:1597)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.manufacturePojo(PodamFactoryImpl.java:175)
    	at uk.co.jemos.podam.api.PodamFactoryImpl.manufacturePojo(PodamFactoryImpl.java:164)
    	at uk.co.jemos.podam.test.unit.pdm45.Pdm45UnitTest.testConstructorMultiDimensionalPojo(Pdm45UnitTest.java:102)

Instead of that we can pass instance of  POJO object to manufactureAttributeValue() and getDefaultFieldValue() instead of POJO type to make production more efficient.
