### PR TITLE
Methods starting with "set" and having non single parameter will prevent POJO construction

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1512,9 +1512,9 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			parameterTypes = setter.getParameterTypes();
 			if (parameterTypes.length != 1) {
-				throw new IllegalStateException("A "
-						+ pojoClass.getSimpleName() + "." + setter.getName()
-						+ "() should have only one argument");
+				LOG.warn("Skipping setter with non-single arguments {}.{}",
+						pojoClass.getSimpleName(), setter.getName());
+				continue;
 			}
 
 			// A class which has got an attribute to itself (e.g.

--- a/src/test/java/uk/co/jemos/podam/test/unit/DifferentObjectsTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/DifferentObjectsTest.java
@@ -1,0 +1,24 @@
+package uk.co.jemos.podam.test.unit;
+
+import java.util.Observable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+/**
+ * @author daivanov
+ *
+ */
+public class DifferentObjectsTest {
+
+	private static final PodamFactory factory = new PodamFactoryImpl();
+
+	@Test
+	public void testObservableInstantiation() {
+		Observable observable = factory.manufacturePojo(Observable.class);
+		Assert.assertNotNull("Manufacturing failed", observable);
+	}
+}


### PR DESCRIPTION
For example, `java.util.Observable` cannot be constructed because of `setChanged()` method. Proposed solution is to skip such methods instead of throwing exception.