### PR TITLE
Instantiation fails, if default values for maps and collections are immutable

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -418,7 +418,9 @@ public class PodamFactoryImpl implements PodamFactory {
 							// It's a Map
 						} else if (Map.class.isAssignableFrom(parameterType)) {
 
-							Map<? super Object, ? super Object> mapType = resolveMapType(parameterType);
+							Map<? super Object, ? super Object> defaultValue = null;
+							Map<? super Object, ? super Object> mapType = resolveMapType(
+									parameterType, defaultValue);
 
 							Class<?> keyClass;
 							Class<?> valueClass;
@@ -2337,10 +2339,7 @@ public class PodamFactoryImpl implements PodamFactory {
 			retValue = getDefaultFieldValue(pojo, attributeName);
 		}
 
-		if (null == retValue) {
-
-			retValue = resolveMapType(attributeType);
-		}
+		retValue = resolveMapType(attributeType, retValue);
 
 		try {
 
@@ -2815,26 +2814,33 @@ public class PodamFactoryImpl implements PodamFactory {
 	 *
 	 * @param mapType
 	 *            The attribute type implementing Map
+	 * @param defaultValue
+	 *            Default value for map
 	 * @return A default instance for each map type
 	 *
 	 */
-	@SuppressWarnings({ UNCHECKED_STR, RAWTYPES_STR })
 	private Map<? super Object, ? super Object> resolveMapType(
-			Class<?> mapType) {
+			Class<?> mapType, Map<? super Object, ? super Object> defaultValue) {
 
 		Map<? super Object, ? super Object> retValue = null;
 
-		if (SortedMap.class.isAssignableFrom(mapType)) {
-			if (mapType.isAssignableFrom(TreeMap.class)) {
-				retValue = new TreeMap();
-			}
-		} else if (ConcurrentMap.class.isAssignableFrom(mapType)) {
-			if (mapType.isAssignableFrom(ConcurrentHashMap.class)) {
-				retValue = new ConcurrentHashMap();
-			}
+		if (null != defaultValue &&
+				(defaultValue.getClass().getModifiers() & Modifier.PRIVATE) == 0) {
+			/* Default map, which is not immutable */
+			retValue = defaultValue;
 		} else {
-			if (mapType.isAssignableFrom(HashMap.class)) {
-				retValue = new HashMap();
+			if (SortedMap.class.isAssignableFrom(mapType)) {
+				if (mapType.isAssignableFrom(TreeMap.class)) {
+					retValue = new TreeMap<Object, Object>();
+				}
+			} else if (ConcurrentMap.class.isAssignableFrom(mapType)) {
+				if (mapType.isAssignableFrom(ConcurrentHashMap.class)) {
+					retValue = new ConcurrentHashMap<Object, Object>();
+				}
+			} else {
+				if (mapType.isAssignableFrom(HashMap.class)) {
+					retValue = new HashMap<Object, Object>();
+				}
 			}
 		}
 		if (null == retValue) {
@@ -2932,7 +2938,8 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			} else if (Map.class.isAssignableFrom(parameterType)) {
 
-				Map<? super Object, ? super Object> mapType = resolveMapType(parameterType);
+				Map<? super Object, ? super Object> defaultValue = null;
+				Map<? super Object, ? super Object> mapType = resolveMapType(parameterType, defaultValue);
 
 				Type type = constructor.getGenericParameterTypes()[idx];
 

--- a/src/test/java/uk/co/jemos/podam/test/dto/ImmutableDefaultFieldsPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ImmutableDefaultFieldsPojo.java
@@ -1,0 +1,35 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author divanov
+ *
+ */
+public class ImmutableDefaultFieldsPojo {
+
+	private List<String> list = Collections.singletonList("key");
+
+	private Map<String, Integer> map = Collections.singletonMap("key", 100);
+
+	public List<String> getList() {
+		return list;
+	}
+
+	public void setList(List<String> list) {
+		this.list = list;
+	}
+
+	public Map<String, Integer> getMap() {
+		return map;
+	}
+
+	public void setMap(Map<String, Integer> map) {
+		this.map = map;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/DifferentObjectsTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/DifferentObjectsTest.java
@@ -5,8 +5,10 @@ import java.util.Observable;
 import org.junit.Assert;
 import org.junit.Test;
 
+import uk.co.jemos.podam.api.DataProviderStrategy;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.ImmutableDefaultFieldsPojo;
 
 /**
  * @author daivanov
@@ -20,5 +22,20 @@ public class DifferentObjectsTest {
 	public void testObservableInstantiation() {
 		Observable observable = factory.manufacturePojo(Observable.class);
 		Assert.assertNotNull("Manufacturing failed", observable);
+	}
+	
+	@Test
+	public void testImmutableDefaultFieldsPojoInstantiation() {
+		ImmutableDefaultFieldsPojo model = factory.manufacturePojo(ImmutableDefaultFieldsPojo.class);
+		Assert.assertNotNull("Manufacturing failed", model);
+		Assert.assertNotNull("List manufacturing failed", model.getList());
+		Assert.assertNotNull("Map manufacturing failed", model.getMap());
+		DataProviderStrategy strategy = factory.getStrategy();
+		Assert.assertEquals("List is not filled",
+				strategy.getNumberOfCollectionElements(model.getList().getClass()),
+				model.getList().size());
+		Assert.assertEquals("Map is not filled",
+				strategy.getNumberOfCollectionElements(model.getMap().getClass()),
+				model.getMap().size());
 	}
 }


### PR DESCRIPTION
Inspect default values and if they are immutable, which effectively means they are private classes, and replace them with normal maps or collections.