### PR TITLE
Added support for custom data type factories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,12 @@
 			<version>3.0.5.RELEASE</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<reporting>

--- a/src/main/java/uk/co/jemos/podam/api/DataTypeFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/DataTypeFactory.java
@@ -1,0 +1,7 @@
+package uk.co.jemos.podam.api;
+
+public interface DataTypeFactory<T> {
+
+    public T manufacture();
+
+}

--- a/src/main/java/uk/co/jemos/podam/api/LoggingExternalFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/LoggingExternalFactory.java
@@ -77,4 +77,9 @@ public class LoggingExternalFactory implements PodamFactory {
 		return null;
 	}
 
+	@Override
+	public <T> PodamFactory withDataTypeFactory(Class<T> clazz, DataTypeFactory<T> dataTypeFactory) {
+		return null;
+	}
+
 }

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
@@ -3,9 +3,9 @@
  */
 package uk.co.jemos.podam.api;
 
-import java.lang.reflect.Type;
-
 import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+import java.lang.reflect.Type;
 
 /**
  * Contract for PODAM factory
@@ -70,4 +70,5 @@ public interface PodamFactory {
 	 */
 	DataProviderStrategy getStrategy();
 
+	<T> PodamFactory withDataTypeFactory(Class<T> clazz, DataTypeFactory<T> dataTypeFactory);
 }

--- a/src/test/java/uk/co/jemos/podam/test/dto/ExternalLibraryPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ExternalLibraryPojo.java
@@ -1,0 +1,16 @@
+package uk.co.jemos.podam.test.dto;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExternalLibraryPojo {
+
+    private final ImmutableList<Double> doubles;
+
+    public ExternalLibraryPojo(ImmutableList<Double> doubles) {
+        this.doubles = doubles;
+    }
+
+    public ImmutableList<Double> getDoubles() {
+        return doubles;
+    }
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/DataTypeFactoryTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/DataTypeFactoryTest.java
@@ -1,0 +1,41 @@
+package uk.co.jemos.podam.test.unit;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import uk.co.jemos.podam.api.DataTypeFactory;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.ExternalLibraryPojo;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataTypeFactoryTest {
+
+    @Test
+    public void shouldUseProvidedDataTypeFactoryToManufacturePojo() throws Exception {
+        PodamFactory podamFactory = new PodamFactoryImpl().withDataTypeFactory(ImmutableList.class, new ImmutableListFactory());
+
+        ImmutableList immutableList = podamFactory.manufacturePojo(ImmutableList.class);
+
+        assertEquals(1, immutableList.size());
+    }
+
+    @Test
+    public void shouldUseProvidedDataTypeFactoryToManufacturePojoInsideClass() throws Exception {
+        PodamFactory podamFactory = new PodamFactoryImpl().withDataTypeFactory(ImmutableList.class, new ImmutableListFactory());
+
+        ExternalLibraryPojo externalLibraryPojo = podamFactory.manufacturePojo(ExternalLibraryPojo.class);
+
+        assertEquals(1, externalLibraryPojo.getDoubles().size());
+    }
+
+
+
+    private static class ImmutableListFactory implements DataTypeFactory<ImmutableList> {
+
+        @Override
+        public ImmutableList manufacture() {
+            return ImmutableList.of(Math.random());
+        }
+    }
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/MultipleInterfacesInheritanceTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/MultipleInterfacesInheritanceTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Test;
 
+import uk.co.jemos.podam.api.*;
 import uk.co.jemos.podam.test.dto.MultipleInterfacesHolderPojo;
 import uk.co.jemos.podam.test.dto.MultipleInterfacesListPojo;
 import uk.co.jemos.podam.test.dto.MultipleInterfacesMapPojo;
@@ -41,6 +42,11 @@ public class MultipleInterfacesInheritanceTest {
 
 		@Override
 		public DataProviderStrategy getStrategy() {
+			return null;
+		}
+
+		@Override
+		public <T> PodamFactory withDataTypeFactory(Class<T> clazz, DataTypeFactory<T> dataTypeFactory) {
 			return null;
 		}
 	}

--- a/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.DataTypeFactory;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 import uk.co.jemos.podam.test.dto.CollectionExtendingGenericsPojo;
@@ -52,6 +53,11 @@ public class Pdm3PojoUnitTest {
 
 		@Override
 		public DataProviderStrategy getStrategy() {
+			return null;
+		}
+
+		@Override
+		public <T> PodamFactory withDataTypeFactory(Class<T> clazz, DataTypeFactory<T> dataTypeFactory) {
 			return null;
 		}
 	}


### PR DESCRIPTION
Added support for custom data type factories that allow to manufacture pojos from external libraries like guava that cannot be manufactured otherwise.
Extension point implemented here doesn't require any external dependencies.
I see some flaws of the implementation. Now it doesn't handle generics and I think it could be improved.

What are your thoughts?