### PR TITLE
Fill read-only complex attributes

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -79,6 +79,8 @@ public class PodamFactoryImpl implements PodamFactory {
 
 	private static final Type[] NO_TYPES = new Type[0];
 
+	private static final Object[] NO_ARGS = new Object[0];
+
 	/** Application logger */
 	private static final Logger LOG = LoggerFactory
 			.getLogger(PodamFactoryImpl.class.getName());
@@ -1371,22 +1373,52 @@ public class PodamFactoryImpl implements PodamFactory {
 			memoizationTable.put(pojoClass, retValue);
 		}
 
-		/* Construction failed, no point to continue */
-		if (retValue == null) {
-			return null;
+		if (retValue != null) {
+			populatePojo(retValue, pojos, genericTypeArgs);
 		}
 
-		if (retValue instanceof Collection && ((Collection<?>)retValue).size() == 0) {
-			fillCollection((Collection<? super Object>)retValue, pojos, genericTypeArgs);
-		} else if (retValue instanceof Map && ((Map<?,?>)retValue).size() == 0) {
-			fillMap((Map<? super Object,? super Object>)retValue, pojos, genericTypeArgs);
+		return retValue;
+	}
+
+	/**
+	 * Fills given class filled with values dictated by the strategy
+	 *
+	 * @param pojo
+	 *            An instance to be filled with dummy values
+	 * @param pojos
+	 *            How many times {@code pojoClass} has been found. This will be
+	 *            used for reentrant objects
+	 * @param genericTypeArgs
+	 *            The generic type arguments for the current generic class
+	 *            instance
+	 * @return An instance of <T> filled with dummy values
+	 * @throws ClassNotFoundException 
+	 * @throws InvocationTargetException 
+	 * @throws IllegalAccessException 
+	 * @throws InstantiationException 
+	 */
+	@SuppressWarnings(UNCHECKED_STR)
+	private <T> T populatePojo(T pojo, Map<Class<?>, Integer> pojos,
+			Type... genericTypeArgs)
+			throws InstantiationException, IllegalAccessException,
+			InvocationTargetException, ClassNotFoundException {
+
+		Class<?> pojoClass = pojo.getClass();
+		if (pojo instanceof Collection && ((Collection<?>)pojo).size() == 0) {
+			fillCollection((Collection<? super Object>)pojo, pojos, genericTypeArgs);
+		} else if (pojo instanceof Map && ((Map<?,?>)pojo).size() == 0) {
+			fillMap((Map<? super Object,? super Object>)pojo, pojos, genericTypeArgs);
 		}
 
 		Class<?>[] parameterTypes = null;
 		Class<?> attributeType = null;
 
-		ClassInfo classInfo = PodamUtils.getClassInfo(pojoClass,
+		ClassInfo classInfo = PodamUtils.getClassInfo(pojo.getClass(),
 				strategy.getExcludedAnnotations());
+
+		Set<String> readOnlyFields = classInfo.getClassFields();
+
+		final Map<String, Type> typeArgsMap = new HashMap<String, Type>();
 
 		// According to JavaBeans standards, setters should have only
 		// one argument
@@ -1394,10 +1426,11 @@ public class PodamFactoryImpl implements PodamFactory {
 		for (Method setter : classInfo.getClassSetters()) {
 
 			List<Annotation> pojoAttributeAnnotations = retrieveFieldAnnotations(
-					pojoClass, setter);
+					pojo.getClass(), setter);
 
 			String attributeName = PodamUtils
 					.extractFieldNameFromSetterMethod(setter);
+			readOnlyFields.remove(attributeName);
 
 			parameterTypes = setter.getParameterTypes();
 			if (parameterTypes.length != 1) {
@@ -1435,13 +1468,13 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			} else {
 
-				final Map<String, Type> typeArgsMap = new HashMap<String, Type>();
-
-				Type[] genericTypeArgsExtra = fillTypeArgMap(typeArgsMap,
-						pojoClass, genericTypeArgs);
-				if (genericTypeArgsExtra != null) {
-					LOG.warn("Lost generic type arguments {}",
-							Arrays.toString(genericTypeArgsExtra));
+				if (typeArgsMap.isEmpty()) {
+					Type[] genericTypeArgsExtra = fillTypeArgMap(typeArgsMap,
+							pojoClass, genericTypeArgs);
+					if (genericTypeArgsExtra != null) {
+						LOG.warn("Lost generic type arguments {}",
+								Arrays.toString(genericTypeArgsExtra));
+					}
 				}
 
 				Type[] typeArguments = NO_TYPES;
@@ -1479,7 +1512,7 @@ public class PodamFactoryImpl implements PodamFactory {
 					}
 				}
 
-				setterArg = manufactureAttributeValue(retValue, pojos,
+				setterArg = manufactureAttributeValue(pojo, pojos,
 						attributeType, setter.getGenericParameterTypes()[0],
 						pojoAttributeAnnotations, attributeName,
 						typeArgsMap, typeArguments);
@@ -1490,25 +1523,66 @@ public class PodamFactoryImpl implements PodamFactory {
 
 			if (setterArg != null) {
 				try {
-					setter.invoke(retValue, setterArg);
+					setter.invoke(pojo, setterArg);
 				} catch(IllegalAccessException e) {
 					LOG.warn("{} is not accessible. Setting it to accessible."
 							+ " However this is a security hack and your code"
 							+ " should really adhere to JavaBeans standards.",
 							setter.toString());
 					setter.setAccessible(true);
-					setter.invoke(retValue, setterArg);
+					setter.invoke(pojo, setterArg);
 				}
 			} else {
 				LOG.warn("Couldn't find a suitable value for attribute {}[{}]"
 						+ ". It will be left to null.",
 						pojoClass, attributeType);
 			}
-
 		}
 
-		return retValue;
+		for (String readOnlyField : readOnlyFields) {
 
+			Field field = getField(pojo.getClass(), readOnlyField);
+			Method getter = PodamUtils.getGetterFor(field);
+			if (getter != null && !getter.getReturnType().isPrimitive()) {
+
+				if (getter.getGenericParameterTypes().length == 0) {
+
+					Object fieldValue = getter.invoke(pojo, NO_ARGS);
+					if (fieldValue != null) {
+
+						LOG.debug("Populating read-only field {}", field);
+						Type[] genericTypeArgsAll;
+						if (field.getGenericType() instanceof ParameterizedType) {
+
+							if (typeArgsMap.isEmpty()) {
+								Type[] genericTypeArgsExtra = fillTypeArgMap(typeArgsMap,
+										pojoClass, genericTypeArgs);
+								if (genericTypeArgsExtra != null) {
+									LOG.warn("Lost generic type arguments {}",
+											Arrays.toString(genericTypeArgsExtra));
+								}
+							}
+
+							ParameterizedType paramType
+									= (ParameterizedType) field.getGenericType();
+							Type[] actualTypes = paramType.getActualTypeArguments();
+							genericTypeArgsAll = mergeActualAndSuppliedGenericTypes(
+									actualTypes, genericTypeArgs,
+									typeArgsMap);
+						} else {
+
+							genericTypeArgsAll = genericTypeArgs;
+						}
+						populatePojo(fieldValue, pojos, genericTypeArgsAll);
+					}
+				} else {
+
+					LOG.warn("Skipping invalid getter {}", getter);
+				}
+			}
+		}
+
+		return pojo;
 	}
 
 	/**
@@ -1753,13 +1827,19 @@ public class PodamFactoryImpl implements PodamFactory {
 	 *            resolved
 	 */
 	private Type[] mergeActualAndSuppliedGenericTypes(
-			TypeVariable<?>[] actualTypes, Type[] suppliedTypes,
+			Type[] actualTypes, Type[] suppliedTypes,
 			Map<String, Type> typeArgsMap) {
 
 		List<Type> resolvedTypes = new ArrayList<Type>();
 		List<Type> substitutionTypes = new ArrayList<Type>(Arrays.asList(suppliedTypes));
 		for (int i = 0; i < actualTypes.length; i++) {
-			Type type = typeArgsMap.get(actualTypes[i].getName());
+
+			Type type = null;
+			if (actualTypes[i] instanceof TypeVariable) {
+				type = typeArgsMap.get(((TypeVariable<?>)actualTypes[i]).getName());
+			} else if (actualTypes[i] instanceof Class) {
+				type = actualTypes[i];
+			}
 			if (type != null) {
 				resolvedTypes.add(type);
 				if (!substitutionTypes.isEmpty() && substitutionTypes.get(0).equals(type)) {

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1855,6 +1855,11 @@ public class PodamFactoryImpl implements PodamFactory {
 				type = typeArgsMap.get(((TypeVariable<?>)actualTypes[i]).getName());
 			} else if (actualTypes[i] instanceof Class) {
 				type = actualTypes[i];
+			} else if (actualTypes[i] instanceof WildcardType) {
+				AtomicReference<Type[]> methodGenericTypeArgs
+						= new AtomicReference<Type[]>(NO_TYPES);
+				type = resolveGenericParameter(actualTypes[i], typeArgsMap,
+						methodGenericTypeArgs);
 			}
 			if (type != null) {
 				resolvedTypes.add(type);

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1574,6 +1574,20 @@ public class PodamFactoryImpl implements PodamFactory {
 							genericTypeArgsAll = genericTypeArgs;
 						}
 
+						if (field.getType().getTypeParameters().length > genericTypeArgsAll.length) {
+
+							Type[] missing = new Type[
+									field.getType().getTypeParameters().length
+									- genericTypeArgsAll.length];
+							for (int i = 0; i < missing.length; i++) {
+								missing[i] = Object.class;
+							}
+							LOG.warn("Missing type parameters, appended {}",
+									Arrays.toString(missing));
+							genericTypeArgsAll =
+									mergeTypeArrays(genericTypeArgsAll, missing);
+						}
+
 						Class<?> fieldClass = fieldValue.getClass();
 						Integer depth = pojos.get(fieldClass);
 						if (depth == null) {

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1573,7 +1573,23 @@ public class PodamFactoryImpl implements PodamFactory {
 
 							genericTypeArgsAll = genericTypeArgs;
 						}
-						populatePojo(fieldValue, pojos, genericTypeArgsAll);
+
+						Class<?> fieldClass = fieldValue.getClass();
+						Integer depth = pojos.get(fieldClass);
+						if (depth == null) {
+							depth = -1;
+						}
+						if (depth <= strategy.getMaxDepth(fieldClass)) {
+
+							pojos.put(fieldClass, depth + 1);
+							populatePojo(fieldValue, pojos, genericTypeArgsAll);
+							pojos.put(fieldClass, depth);
+
+						} else {
+
+							LOG.warn("Loop in filling read-only field {} detected.",
+									field);
+						}
 					}
 				} else {
 

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -1332,18 +1332,15 @@ public class PodamFactoryImpl implements PodamFactory {
 					new AttributeMetadata(noName, pojoClass, annotations, pojoClass));
 		}
 
-		if (pojoClass.isInterface()
-				|| Modifier.isAbstract(pojoClass.getModifiers())) {
+		if (pojoClass.isInterface()) {
 			Class<T> specificClass = (Class<T>) strategy
 					.getSpecificClass(pojoClass);
 			if (!specificClass.equals(pojoClass)) {
 				return this.manufacturePojoInternal(specificClass, pojos,
 						genericTypeArgs);
 			} else {
-				if (specificClass.isInterface()) {
-					return externalFactory.manufacturePojo(pojoClass,
-							genericTypeArgs);
-				}
+				return externalFactory.manufacturePojo(pojoClass,
+						genericTypeArgs);
 			}
 		}
 
@@ -1353,6 +1350,18 @@ public class PodamFactoryImpl implements PodamFactory {
 		} catch (SecurityException e) {
 			throw new PodamMockeryException(
 					"Security exception while applying introspection.", e);
+		}
+
+		if (retValue == null && Modifier.isAbstract(pojoClass.getModifiers())) {
+			Class<T> specificClass = (Class<T>) strategy
+					.getSpecificClass(pojoClass);
+			if (!specificClass.equals(pojoClass)) {
+				return this.manufacturePojoInternal(specificClass, pojos,
+						genericTypeArgs);
+			} else {
+				return externalFactory.manufacturePojo(pojoClass,
+						genericTypeArgs);
+			}
 		}
 
 		// update memoization table with new object

--- a/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyComplexTypesPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyComplexTypesPojo.java
@@ -1,0 +1,44 @@
+package uk.co.jemos.podam.test.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic POJO with read only complex type fields
+ *
+ * @author daivanov
+ */
+public class ReadOnlyComplexTypesPojo {
+
+	public static class Value {
+		private String value;
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	private List<Integer> list = new ArrayList<Integer>();
+
+	private Map<Long, String> map = new HashMap<Long, String>();
+	
+	private Value value = new Value();
+
+	public List<Integer> getList() {
+		return list;
+	}
+
+	public Map<Long, String> getMap() {
+		return map;
+	}
+
+	public Value getValue() {
+		return value;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyGenericComplexTypesPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyGenericComplexTypesPojo.java
@@ -1,0 +1,44 @@
+package uk.co.jemos.podam.test.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic POJO with read only complex type fields
+ *
+ * @author daivanov
+ */
+public class ReadOnlyGenericComplexTypesPojo<T, E, K> {
+
+	public static class Value<T> {
+		private T value;
+
+		public T getValue() {
+			return value;
+		}
+
+		public void setValue(T value) {
+			this.value = value;
+		}
+	}
+
+	private List<E> list = new ArrayList<E>();
+
+	private Map<K, String> map = new HashMap<K, String>();
+	
+	private Value<T> value = new Value<T>();
+
+	public List<E> getList() {
+		return list;
+	}
+
+	public Map<K, String> getMap() {
+		return map;
+	}
+
+	public Value<T> getValue() {
+		return value;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyRawFieldsPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyRawFieldsPojo.java
@@ -1,0 +1,37 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * POJO to test read-only fields with wildcards instantiation
+ *
+ * @author daivanov
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class ReadOnlyRawFieldsPojo {
+
+	private Class clazz = Object.class;
+
+	private List list = new ArrayList<Object>();
+
+	private Map map = new HashMap<Object, Object>();
+
+	public Class getClazz() {
+		return clazz;
+	}
+
+	public List getList() {
+		return list;
+	}
+
+	public Map getMap() {
+		return map;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyWildcardFieldsPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/ReadOnlyWildcardFieldsPojo.java
@@ -1,0 +1,36 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * POJO to test read-only fields with wildcards instantiation
+ *
+ * @author daivanov
+ *
+ */
+public class ReadOnlyWildcardFieldsPojo {
+
+	private Class<?> clazz = Object.class;
+
+	private List<?> list = new ArrayList<Object>();
+
+	private Map<?, ?> map = new HashMap<Object, Object>();
+
+	public Class<?> getClazz() {
+		return clazz;
+	}
+
+	public List<?> getList() {
+		return list;
+	}
+
+	public Map<?, ?> getMap() {
+		return map;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 import uk.co.jemos.podam.test.dto.ReadOnlyComplexTypesPojo;
+import uk.co.jemos.podam.test.dto.ReadOnlyGenericComplexTypesPojo;
 import uk.co.jemos.podam.test.utils.PodamTestUtils;
 
 /**
@@ -27,5 +28,22 @@ public class ReadOnlyComplexTypesTest {
 		PodamTestUtils.assertMapElementsType(pojo.getMap(), Long.class, String.class);
 		Assert.assertNotNull("Complex element should not be empty",
 				pojo.getValue().getValue());
+	}
+
+	@Test
+	public void testReadOnlyGenericComplexTypesPojoInstantiation() {
+		ReadOnlyGenericComplexTypesPojo<?, ?, ?> pojo
+				= factory.manufacturePojo(ReadOnlyGenericComplexTypesPojo.class,
+						Character.class, Long.class, Integer.class);
+		Assert.assertNotNull("Manufacturing failed", pojo);
+		Assert.assertNotNull("List should be present", pojo.getList());
+		Assert.assertNotNull("Map should be present", pojo.getMap());
+		Assert.assertNotNull("Complex element should be present", pojo.getValue());
+		PodamTestUtils.assertListElementsType(pojo.getList(), Long.class);
+		PodamTestUtils.assertMapElementsType(pojo.getMap(), Integer.class, String.class);
+		Assert.assertNotNull("Complex element should not be empty",
+				pojo.getValue().getValue());
+		Assert.assertEquals("Wrong element type", Character.class,
+				pojo.getValue().getValue().getClass());
 	}
 }

--- a/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
@@ -1,0 +1,31 @@
+package uk.co.jemos.podam.test.unit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.ReadOnlyComplexTypesPojo;
+import uk.co.jemos.podam.test.utils.PodamTestUtils;
+
+/**
+ * @author daivanov
+ *
+ */
+public class ReadOnlyComplexTypesTest {
+
+	private static final PodamFactory factory = new PodamFactoryImpl();
+
+	@Test
+	public void testReadOnlyComplexTypesPojoInstantiation() {
+		ReadOnlyComplexTypesPojo pojo = factory.manufacturePojo(ReadOnlyComplexTypesPojo.class);
+		Assert.assertNotNull("Manufacturing failed", pojo);
+		Assert.assertNotNull("List should be present", pojo.getList());
+		Assert.assertNotNull("Map should be present", pojo.getMap());
+		Assert.assertNotNull("Complex element should be present", pojo.getValue());
+		PodamTestUtils.assertListElementsType(pojo.getList(), Integer.class);
+		PodamTestUtils.assertMapElementsType(pojo.getMap(), Long.class, String.class);
+		Assert.assertNotNull("Complex element should not be empty",
+				pojo.getValue().getValue());
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.ReadOnlyWildcardFieldsPojo;
 import uk.co.jemos.podam.test.dto.ReadOnlyComplexTypesPojo;
 import uk.co.jemos.podam.test.dto.ReadOnlyGenericComplexTypesPojo;
 import uk.co.jemos.podam.test.utils.PodamTestUtils;
@@ -53,5 +54,14 @@ public class ReadOnlyComplexTypesTest {
 	public void testLoopInFillingReadOnlyFields() {
 		Object pojo = factory.manufacturePojo(BeanContextServicesSupport.class);
 		Assert.assertNotNull("Manufacturing failed", pojo);
+	}
+
+	@Test
+	public void testAttributeWithWildcards() {
+		ReadOnlyWildcardFieldsPojo pojo
+				= factory.manufacturePojo(ReadOnlyWildcardFieldsPojo.class);
+		Assert.assertNotNull("Manufacturing failed", pojo);
+		PodamTestUtils.assertListElementsType(pojo.getList(), Object.class);
+		PodamTestUtils.assertMapElementsType(pojo.getMap(), Object.class, Object.class);
 	}
 }

--- a/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
+import uk.co.jemos.podam.test.dto.ReadOnlyRawFieldsPojo;
 import uk.co.jemos.podam.test.dto.ReadOnlyWildcardFieldsPojo;
 import uk.co.jemos.podam.test.dto.ReadOnlyComplexTypesPojo;
 import uk.co.jemos.podam.test.dto.ReadOnlyGenericComplexTypesPojo;
@@ -60,6 +61,15 @@ public class ReadOnlyComplexTypesTest {
 	public void testAttributeWithWildcards() {
 		ReadOnlyWildcardFieldsPojo pojo
 				= factory.manufacturePojo(ReadOnlyWildcardFieldsPojo.class);
+		Assert.assertNotNull("Manufacturing failed", pojo);
+		PodamTestUtils.assertListElementsType(pojo.getList(), Object.class);
+		PodamTestUtils.assertMapElementsType(pojo.getMap(), Object.class, Object.class);
+	}
+
+	@Test
+	public void testAttributeWithRawTypes() {
+		ReadOnlyRawFieldsPojo pojo
+				= factory.manufacturePojo(ReadOnlyRawFieldsPojo.class);
 		Assert.assertNotNull("Manufacturing failed", pojo);
 		PodamTestUtils.assertListElementsType(pojo.getList(), Object.class);
 		PodamTestUtils.assertMapElementsType(pojo.getMap(), Object.class, Object.class);

--- a/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ReadOnlyComplexTypesTest.java
@@ -1,5 +1,7 @@
 package uk.co.jemos.podam.test.unit;
 
+import java.beans.beancontext.BeanContextServicesSupport;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,5 +47,11 @@ public class ReadOnlyComplexTypesTest {
 				pojo.getValue().getValue());
 		Assert.assertEquals("Wrong element type", Character.class,
 				pojo.getValue().getValue().getClass());
+	}
+
+	@Test
+	public void testLoopInFillingReadOnlyFields() {
+		Object pojo = factory.manufacturePojo(BeanContextServicesSupport.class);
+		Assert.assertNotNull("Manufacturing failed", pojo);
 	}
 }


### PR DESCRIPTION
JAXB creates classes with read-only complex attributes like this

    class Class {
        private List<String> list = new ArrayList<String>();
        public List<String>getList() {
            return list;
        }
    }

At the moment such attributes are left behind. This set of patches is correcting such situation.