### PR TITLE
Exclude POJO attributes by names

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
@@ -1,0 +1,145 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.api;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Default abstract implementation of a {@link ClassInfoStrategy}
+ * <p>
+ * This default implementation is based on field introspection.
+ * </p>
+ *
+ * @author daivanov
+ *
+ * @since 5.1.0
+ *
+ */
+
+public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy {
+
+	// ------------------->> Constants
+
+	// ------------------->> Instance / Static variables
+
+	/**
+	 * Set of annotations, which mark fields to be skipped from populating.
+	 */
+	private final Set<Class<? extends Annotation>> excludedAnnotations =
+			new HashSet<Class<? extends Annotation>>();
+
+	/**
+	 * Set of fields, which mark fields to be skipped from populating.
+	 */
+	private Map<Class<?>, Set<String>> excludedFields
+			= new HashMap<Class<?>, Set<String>>();
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * Adds the specified {@link Annotation} to set of excluded annotations,
+	 * if it is not already present.
+	 *
+	 * @param annotation
+	 *            the annotation to use as an exclusion mark
+	 * @return itself
+	 */
+	public AbstractClassInfoStrategy addExcludedAnnotation(
+			final Class<? extends Annotation> annotation) {
+		excludedAnnotations.add(annotation);
+		return this;
+	}
+
+	/**
+	 * Removes the specified {@link Annotation} from set of excluded annotations.
+	 *
+	 * @param annotation
+	 *            the annotation used as an exclusion mark
+	 * @return itself
+	 */
+	public AbstractClassInfoStrategy removeExcludedAnnotation(
+			final Class<? extends Annotation> annotation) {
+		excludedAnnotations.remove(annotation);
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Set<Class<? extends Annotation>> getExcludedAnnotations() {
+		return excludedAnnotations;
+	}
+
+	/**
+	 * Adds the specified field to set of excluded fields,
+	 * if it is not already present.
+	 *
+	 * @param pojoClass
+	 *        a class for which fields should be skipped
+	 * @param fieldName
+	 *            the field name to use as an exclusion mark
+	 * @return itself
+	 */
+	public AbstractClassInfoStrategy addExcludedField(
+			final Class<?> pojoClass, final String fieldName) {
+		Set<String> fields = excludedFields.get(pojoClass);
+		if (fields == null) {
+			fields = new HashSet<String>();
+			excludedFields.put(pojoClass, fields);
+		}
+		fields.add(fieldName);
+		return this;
+	}
+
+	/**
+	 * Removes the field name from set of excluded fields.
+	 *
+	 * @param pojoClass
+	 *        a class for which fields should be skipped
+	 * @param fieldName
+	 *            the field name used as an exlusion mark
+	 * @return itself
+	 */
+	public AbstractClassInfoStrategy removeExcludedField(
+			final Class<?> pojoClass, final String fieldName) {
+		Set<String> fields = excludedFields.get(pojoClass);
+		if (fields != null) {
+			fields.remove(fieldName);
+		}
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Set<String> getExcludedFields(final Class<?> pojoClass) {
+		return excludedFields.get(pojoClass);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ClassInfo getClassInfo(Class<?> pojoClass) {
+		return PodamUtils.getClassInfo(pojoClass,
+				excludedAnnotations, excludedFields.get(pojoClass));
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+
+}

--- a/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
@@ -3,14 +3,11 @@
  */
 package uk.co.jemos.podam.api;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.Random;
 
 import uk.co.jemos.podam.common.AbstractConstructorComparator;
@@ -77,12 +74,6 @@ public abstract class AbstractRandomDataProviderStrategy implements DataProvider
 	 * abstract classes
 	 */
 	private final Map<Class<?>, Class<?>> specificTypes = new HashMap<Class<?>, Class<?>>();
-
-	/**
-	 * Set of annotations, which mark fields to be skipped from populating.
-	 */
-	private final Set<Class<? extends Annotation>> excludedAnnotations =
-			new HashSet<Class<? extends Annotation>>();
 
 	/** The constructor comparator */
 	private AbstractConstructorComparator constructorComparator =
@@ -511,41 +502,6 @@ public abstract class AbstractRandomDataProviderStrategy implements DataProvider
 			found = nonInstantiatableClass;
 		}
 		return found;
-	}
-
-	/**
-	 * Adds the specified {@link Annotation} to set of excluded annotations,
-	 * if it is not already present.
-	 *
-	 * @param annotation
-	 *            the annotation to use as an exlusion mark
-	 * @return itself
-	 */
-	public AbstractRandomDataProviderStrategy addExcludedAnnotation(
-			final Class<? extends Annotation> annotation) {
-		excludedAnnotations.add(annotation);
-		return this;
-	}
-
-	/**
-	 * Adds the specified {@link Annotation} from set of excluded annotations.
-	 *
-	 * @param annotation
-	 *            the annotation used as an exlusion mark
-	 * @return itself
-	 */
-	public AbstractRandomDataProviderStrategy removeExcludedAnnotation(
-			final Class<? extends Annotation> annotation) {
-		excludedAnnotations.remove(annotation);
-		return this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public Set<Class<? extends Annotation>> getExcludedAnnotations() {
-		return excludedAnnotations;
 	}
 
 	/**

--- a/src/main/java/uk/co/jemos/podam/api/ClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/ClassInfoStrategy.java
@@ -1,0 +1,54 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.api;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * This interface defines the contact for PODAM class info introspection.
+ * <p>
+ * It provides a tool for customization of class introspection process.
+ * </p>
+ * 
+ * @author daivanov
+ * 
+ * @since 5.1.0
+ * 
+ */
+public interface ClassInfoStrategy {
+
+	/**
+	 * Identifies {@link Annotation}s for fields to be skipped.
+	 * <p>
+	 * Should return set of annotations, which will be treated as notion for
+	 * {@link PodamFactory} to skip production of these particular fields.
+	 * </p>
+	 * 
+	 * @return set of annotations, which mark fields to be skipped from populating.
+	 */
+	Set<Class<? extends Annotation>> getExcludedAnnotations();
+
+	/**
+	 * Identifies fields to be skipped.
+	 * <p>
+	 * Should return set of field names as case-sensitive string, which will
+	 * be treated as notion for {@link PodamFactory} to skip production of
+	 * these particular fields.
+	 * </p>
+	 * 
+	 * @param pojoClass
+	 *        a class for which fields should be skipped
+	 * @return set of field name, which mark fields to be skipped from populating.
+	 */
+	Set<String> getExcludedFields(Class<?> pojoClass);
+
+	/**
+	 * 
+	 * @param pojoClass
+	 *        a class to introspect and fetch attributes
+	 * @return information about class internal structure {@link ClassInfo}
+	 */
+	ClassInfo getClassInfo(Class<?> pojoClass);
+}

--- a/src/main/java/uk/co/jemos/podam/api/DataProviderStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/DataProviderStrategy.java
@@ -3,10 +3,8 @@
  */
 package uk.co.jemos.podam.api;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.Set;
 
 /**
  * This interface defines the contact for PODAM data providers.
@@ -223,15 +221,4 @@ public interface DataProviderStrategy {
 	 *         {@code nonInstantiatableClass}.
 	 */
 	<T> Class<? extends T> getSpecificClass(Class<T> nonInstantiatableClass);
-
-	/**
-	 * Identifies {@link Annotation}s for fields to be skipped.
-	 * <p>
-	 * Should return set of annotations, which will be treated as notion for
-	 * {@link PodamFactory} to skip production of these particular fields.
-	 * </p>
-	 * 
-	 * @return set of annotations, which mark fields to be skipped from populating.
-	 */
-	Set<Class<? extends Annotation>> getExcludedAnnotations();
 }

--- a/src/main/java/uk/co/jemos/podam/api/DefaultClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/DefaultClassInfoStrategy.java
@@ -1,0 +1,73 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.api;
+
+/**
+ * Singleton implementation of a {@link AbstractClassInfoStrategy}
+ * <p>
+ * This singleton implementation performs class attribute introspection
+ * on the basis of class declared fields
+ * </p>
+ *
+ * @author daivanov
+ *
+ * @since 5.1.0
+ *
+ */
+
+public final class DefaultClassInfoStrategy extends
+		AbstractClassInfoStrategy {
+
+	// ------------------->> Constants
+
+	/** The singleton instance of this implementation */
+	private static final DefaultClassInfoStrategy SINGLETON = new DefaultClassInfoStrategy();
+
+	// ------------------->> Instance / Static variables
+
+	// ------------------->> Constructors
+
+	/**
+	 * Implementation of the Singleton pattern
+	 */
+	private DefaultClassInfoStrategy() {
+		super();
+	}
+
+	// ------------------->> Public methods
+
+	/**
+	 * Implementation of the Singleton pattern
+	 *
+	 * @return A singleton instance of this class
+	 */
+	public static DefaultClassInfoStrategy getInstance() {
+		return SINGLETON;
+	}
+
+	/**
+	 * Other factory method which assigns a default number of collection
+	 * elements before returning the singleton.
+	 *
+	 * @param nbrCollectionElements
+	 *            The number of collection elements
+	 * @return The Singleton, set with the number of collection elements set as
+	 *         parameter
+	 */
+	public static DefaultClassInfoStrategy getInstance(
+			int nbrCollectionElements) {
+
+		return SINGLETON;
+
+	}
+
+	// ------------------->> Getters / Setters
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+
+}

--- a/src/main/java/uk/co/jemos/podam/api/LoggingExternalFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/LoggingExternalFactory.java
@@ -86,4 +86,20 @@ public class LoggingExternalFactory implements PodamFactory {
 		return null;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public ClassInfoStrategy getClassStrategy() {
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public PodamFactory setClassStrategy(ClassInfoStrategy classInfoStrategy) {
+		return this;
+	}
+
 }

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactory.java
@@ -95,4 +95,18 @@ public interface PodamFactory {
 	 */
 	DataProviderStrategy getStrategy();
 
+	/**
+	 * It returns the class info strategy for this factory.
+	 *
+	 * @return
+	 */
+	ClassInfoStrategy getClassStrategy();
+
+	/**
+	 * Sets the class info strategy for this factory
+	 *
+	 * @param classInfoStrategy
+	 * @return
+	 */
+	PodamFactory setClassStrategy(ClassInfoStrategy classInfoStrategy);
 }

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -104,6 +104,15 @@ public class PodamFactoryImpl implements PodamFactory {
 	private final DataProviderStrategy strategy;
 
 	/**
+	 * The strategy to use to introspect data.
+	 * <p>
+	 * The default is {@link DefaultClassInfoStrategy}.
+	 * </p>
+	 */
+	private ClassInfoStrategy classInfoStrategy
+			= DefaultClassInfoStrategy.getInstance();
+
+	/**
 	 * A map to keep one object for each class. If memoization is enabled, the
 	 * factory will use this table to avoid creating objects of the same class
 	 * multiple times.
@@ -1413,8 +1422,7 @@ public class PodamFactoryImpl implements PodamFactory {
 		Class<?>[] parameterTypes = null;
 		Class<?> attributeType = null;
 
-		ClassInfo classInfo = PodamUtils.getClassInfo(pojo.getClass(),
-				strategy.getExcludedAnnotations());
+		ClassInfo classInfo = classInfoStrategy.getClassInfo(pojo.getClass());
 
 		Set<String> readOnlyFields = classInfo.getClassFields();
 
@@ -3150,6 +3158,17 @@ public class PodamFactoryImpl implements PodamFactory {
 
 		return retValue;
 
+	}
+
+	@Override
+	public ClassInfoStrategy getClassStrategy() {
+		return classInfoStrategy;
+	}
+
+	@Override
+	public PodamFactory setClassStrategy(ClassInfoStrategy classInfoStrategy) {
+		this.classInfoStrategy = classInfoStrategy;
+		return this;
 	}
 
 	// ------------------->> equals() / hashcode() / toString()

--- a/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
@@ -48,7 +48,7 @@ public final class PodamUtils {
 	 * @return a {@link ClassInfo} object for the given class
 	 */
 	public static ClassInfo getClassInfo(Class<?> clazz) {
-		return getClassInfo(clazz, null);
+		return getClassInfo(clazz, null, null);
 	}
 
 	/**
@@ -59,13 +59,16 @@ public final class PodamUtils {
 	 * @param excludeFieldAnnotations
 	 *            the fields marked with any of these annotations will not be
 	 *            included in the class info
+	 * @param excludedFields
+	 *            the fields will not be included in the class info
 	 * @return a {@link ClassInfo} object for the given class
 	 */
 	public static ClassInfo getClassInfo(Class<?> clazz,
-			Set<Class<? extends Annotation>> excludeFieldAnnotations) {
+			Set<Class<? extends Annotation>> excludeFieldAnnotations,
+			Set<String> excludedFields) {
 
 		Set<String> classFields = getDeclaredInstanceFields(clazz,
-				excludeFieldAnnotations);
+				excludeFieldAnnotations, excludedFields);
 		Set<Method> classSetters = getPojoSetters(clazz, classFields);
 		Constructor<?>[] constructors = clazz.getConstructors();
 		Set<Constructor<?>> constructorsSet = new HashSet<Constructor<?>>(
@@ -82,7 +85,7 @@ public final class PodamUtils {
 	 * @return Set of a class declared field names.
 	 */
 	public static Set<String> getDeclaredInstanceFields(Class<?> clazz) {
-		return getDeclaredInstanceFields(clazz, null);
+		return getDeclaredInstanceFields(clazz, null, null);
 	}
 
 	/**
@@ -93,10 +96,13 @@ public final class PodamUtils {
 	 * @param excludeAnnotations
 	 *            fields marked with any of the mentioned annotations will be
 	 *            skipped
+	 * @param excludedFields
+	 *            the fields will not be included in the class info
 	 * @return Set of a class declared field names.
 	 */
 	public static Set<String> getDeclaredInstanceFields(Class<?> clazz,
-			Set<Class<? extends Annotation>> excludeAnnotations) {
+			Set<Class<? extends Annotation>> excludeAnnotations,
+			Set<String> excludedFields) {
 
 		if (excludeAnnotations == null) {
 			excludeAnnotations = new HashSet<Class<? extends Annotation>>();
@@ -111,7 +117,9 @@ public final class PodamUtils {
 			Field[] declaredFields = workClass.getDeclaredFields();
 			for (Field field : declaredFields) {
 				// If users wanted to skip this field, we grant their wishes
-				if (containsAnyAnnotation(field, excludeAnnotations)) {
+				if (containsAnyAnnotation(field, excludeAnnotations)
+						|| (excludedFields != null
+								&& excludedFields.contains(field.getName()))) {
 					continue;
 				}
 				int modifiers = field.getModifiers();

--- a/src/site/apt/annotations.apt
+++ b/src/site/apt/annotations.apt
@@ -467,20 +467,34 @@ public class ImmutableNoHierarchicalAnnotatedPojo implements Serializable {
 * @PodamExclude
 
   This annotation is used to instruct PODAM to skip the initialisation of a certain attribute. 
-  
+
 *------------+---------------------+
 | Attribute | Description |
 *------------+---------------------+
 | comment | It allows users to write a comment on the use of this annotation |
+*------------+---------------------+
 
   Example: 
-  
+
 +-----------------------------------
 
-/** PODAM will not fill this attribute */
-@PodamExclude
-private SimplePojoToTestSetters somePojo;
+	public class Pojo {
+
+		/** PODAM will not fill this attribute */
+		@PodamExclude
+		private SimplePojoToTestSetters somePojo;
+	}
 
 +----------------------------------- 
 
-  
+  An alternative to this annotation is reloading <ClassInfoStrategy.getExcludedFields()>
+
+  Example: 
+
++-----------------------------------
+
+	private final static DefaultClassInfoStrategy classInfoStrategy =
+			DefaultClassInfoStrategy.getInstance();
+	classInfoStrategy.addExcludedField(Pojo.class, "somePojo");
+
++-----------------------------------

--- a/src/test/java/uk/co/jemos/podam/test/unit/BooleanUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/BooleanUnitTest.java
@@ -7,6 +7,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import uk.co.jemos.podam.api.DefaultClassInfoStrategy;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 import uk.co.jemos.podam.api.RandomDataProviderStrategy;
@@ -26,21 +27,24 @@ public class BooleanUnitTest implements Serializable {
 	private final static RandomDataProviderStrategy strategy =
 			RandomDataProviderStrategy.getInstance();
 
+	private final static DefaultClassInfoStrategy classInfoStrategy =
+			DefaultClassInfoStrategy.getInstance();
+
 	private final static PodamFactory podam = new PodamFactoryImpl(strategy);
 
 	@BeforeClass
 	public static void init() {
-		strategy.addExcludedAnnotation(TestExclude.class);
-		strategy.addExcludedAnnotation(PodamExclude.class);
+		classInfoStrategy.addExcludedAnnotation(TestExclude.class);
+		classInfoStrategy.addExcludedAnnotation(PodamExclude.class);
 		Assert.assertEquals("Unexpected number of exluded annotations",
-				2, strategy.getExcludedAnnotations().size());
+				2, classInfoStrategy.getExcludedAnnotations().size());
 	}
 
 	@AfterClass
 	public static void deinit() {
-		strategy.removeExcludedAnnotation(TestExclude.class);
+		classInfoStrategy.removeExcludedAnnotation(TestExclude.class);
 		Assert.assertEquals("Unexpected number of exluded annotations",
-				1, strategy.getExcludedAnnotations().size());
+				1, classInfoStrategy.getExcludedAnnotations().size());
 	}
 
 	@Test

--- a/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
@@ -80,6 +80,29 @@ public class ClassInfoUnitTest {
 	@Test
 	public void testClassInfoWithExcludeAnnotations() {
 
+		Set<Class<? extends Annotation>> excludeAnnotations = new HashSet<Class<? extends Annotation>>();
+		excludeAnnotations.add(TestExclude.class);
+		Set<String> excludeFields = new HashSet<String>();
+		testClassInfoWithExclusions(excludeAnnotations, excludeFields);
+	}
+
+	@Test
+	public void testClassInfoWithExcludeFields() {
+
+		Set<Class<? extends Annotation>> excludeAnnotations = new HashSet<Class<? extends Annotation>>();
+		Set<String> excludeFields = new HashSet<String>();
+		excludeFields.add("excludeField1");
+		excludeFields.add("excludeField2");
+		excludeFields.add("excludeField3");
+		testClassInfoWithExclusions(excludeAnnotations, excludeFields);
+	}
+
+	// ------------------------------> Private methods
+
+	private void testClassInfoWithExclusions(
+			Set<Class<? extends Annotation>> excludeAnnotations,
+			Set<String> excludeFields) {
+
 		Set<String> pojoFields = retrievePojoFields();
 
 		Set<Method> pojoSetters = PodamUtils.getPojoSetters(
@@ -90,11 +113,9 @@ public class ClassInfoUnitTest {
 		ClassInfo expectedClassInfo = new ClassInfo(
 				SimplePojoWithExcludeAnnotationToTestSetters.class, pojoFields,
 				pojoSetters, constructors);
-		Set<Class<? extends Annotation>> excludeAnnotations = new HashSet<Class<? extends Annotation>>();
-		excludeAnnotations.add(TestExclude.class);
 		ClassInfo actualClassInfo = PodamUtils.getClassInfo(
 				SimplePojoWithExcludeAnnotationToTestSetters.class,
-				excludeAnnotations);
+				excludeAnnotations, excludeFields);
 		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
 		Assert.assertEquals(
 				"The expected and actual ClassInfo objects do not match!",
@@ -109,7 +130,5 @@ public class ClassInfoUnitTest {
 		pojoFields.add("intField");
 		return pojoFields;
 	}
-
-	// ------------------------------> Private methods
 
 }

--- a/src/test/java/uk/co/jemos/podam/test/unit/MultipleInterfacesInheritanceTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/MultipleInterfacesInheritanceTest.java
@@ -13,6 +13,7 @@ import uk.co.jemos.podam.test.dto.MultipleInterfacesHolderPojo;
 import uk.co.jemos.podam.test.dto.MultipleInterfacesListPojo;
 import uk.co.jemos.podam.test.dto.MultipleInterfacesMapPojo;
 import uk.co.jemos.podam.api.AbstractRandomDataProviderStrategy;
+import uk.co.jemos.podam.api.ClassInfoStrategy;
 import uk.co.jemos.podam.api.DataProviderStrategy;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -48,6 +49,16 @@ public class MultipleInterfacesInheritanceTest {
 		@Override
 		public DataProviderStrategy getStrategy() {
 			return null;
+		}
+
+		@Override
+		public ClassInfoStrategy getClassStrategy() {
+			return null;
+		}
+
+		@Override
+		public PodamFactory setClassStrategy(ClassInfoStrategy classInfoStrategy) {
+			return this;
 		}
 	}
 

--- a/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/pdm3/Pdm3PojoUnitTest.java
@@ -18,6 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import uk.co.jemos.podam.api.ClassInfoStrategy;
 import uk.co.jemos.podam.api.DataProviderStrategy;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -67,6 +68,16 @@ public class Pdm3PojoUnitTest {
 		@Override
 		public DataProviderStrategy getStrategy() {
 			return null;
+		}
+
+		@Override
+		public ClassInfoStrategy getClassStrategy() {
+			return null;
+		}
+
+		@Override
+		public PodamFactory setClassStrategy(ClassInfoStrategy classInfoStrategy) {
+			return this;
 		}
 	}
 


### PR DESCRIPTION
Exclude POJO attributes by names. Introduced ClassInfoStrategy to bring customization into attribute introspections in future.