### PR TITLE
Fix for Issue #82

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
@@ -22,7 +22,8 @@ import java.util.Set;
  *
  */
 
-public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy {
+public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy,
+		ClassAttributeApprover {
 
 	// ------------------->> Constants
 
@@ -138,7 +139,15 @@ public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy {
 			excludedAttributes = Collections.emptySet();
 		}
 		return PodamUtils.getClassInfo(pojoClass,
-				excludedAnnotations, excludedAttributes);
+				excludedAnnotations, excludedAttributes, this);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean approve(ClassAttribute attribute) {
+		return (attribute.getAttribute() != null);
 	}
 
 	// ------------------->> Private methods

--- a/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
@@ -4,6 +4,7 @@
 package uk.co.jemos.podam.api;
 
 import java.lang.annotation.Annotation;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -132,8 +133,12 @@ public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy {
 	 */
 	@Override
 	public ClassInfo getClassInfo(Class<?> pojoClass) {
+		Set<String> excludedAttributes = excludedFields.get(pojoClass);
+		if (excludedAttributes == null) {
+			excludedAttributes = Collections.emptySet();
+		}
 		return PodamUtils.getClassInfo(pojoClass,
-				excludedAnnotations, excludedFields.get(pojoClass));
+				excludedAnnotations, excludedAttributes);
 	}
 
 	// ------------------->> Private methods

--- a/src/main/java/uk/co/jemos/podam/api/ClassAttribute.java
+++ b/src/main/java/uk/co/jemos/podam/api/ClassAttribute.java
@@ -1,0 +1,147 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.api;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.jcip.annotations.Immutable;
+
+/**
+ * This class wraps fields, getters and setters information of the same attribute
+ * <p>
+ * The purpose of this class is to carry information about single attribute
+ * of POJO class.
+ * </p>
+ *
+ * @author daivanov
+ *
+ * @since 5.1.0
+ *
+ */
+@Immutable
+public class ClassAttribute implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The Set of fields belonging to this class */
+	private final Field attribute;
+
+	/** The Set of getters for this attribute in the class */
+	private final Set<Method> getters = new HashSet<Method>();
+
+	/** The Set of setters for this attribute in the class */
+	private final Set<Method> setters = new HashSet<Method>();
+
+	/**
+	 * Full constructor
+	 *
+	 * @param field
+	 *            attribute, can be null
+	 * @param getters
+	 *            The set of getters for this attributes
+	 * @param setters
+	 *            The set of setters for this attributes
+	 */
+	public ClassAttribute(Field attribute, Set<Method> getters, Set<Method> setters) {
+		this.attribute = attribute;
+		this.getters.addAll(getters);
+		this.setters.addAll(setters);
+	}
+
+	/**
+	 * It returns the attribute
+	 *
+	 * @return the classFields
+	 */
+	public Field getAttribute() {
+		return attribute;
+	}
+
+	/**
+	 * It returns the attribute getters
+	 *
+	 * @return the getters
+	 */
+	public Set<Method> getGetters() {
+		return new HashSet<Method>(getters);
+	}
+
+	Set<Method> getRawGetters() {
+		return getters;
+	}
+
+	/**
+	 * It returns the attribute setters
+	 *
+	 * @return the setters
+	 */
+	public Set<Method> getSetters() {
+		return new HashSet<Method>(setters);
+	}
+
+	Set<Method> getRawSetters() {
+		return setters;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+
+		int hashCode = getters.hashCode() ^ setters.hashCode();
+		if (attribute != null) {
+			hashCode ^= attribute.hashCode();
+		}
+		return hashCode;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ClassAttribute)) {
+			return false;
+		}
+		ClassAttribute other = (ClassAttribute) obj;
+		if (attribute != null && !attribute.equals(other.getAttribute())) {
+			return false;
+		}
+		if (!setters.equals(other.getSetters())) {
+			return false;
+		}
+		if (!getters.equals(other.getGetters())) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(attribute);
+		builder.append("={ getters: {");
+		builder.append(getters);
+		builder.append("}, { setters: {");
+		builder.append(setters);
+		builder.append("}}");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/uk/co/jemos/podam/api/ClassAttributeApprover.java
+++ b/src/main/java/uk/co/jemos/podam/api/ClassAttributeApprover.java
@@ -1,0 +1,24 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.api;
+
+/**
+ * An interface, which is used to customize selection of class' attributes
+ * for further filling or skipping.
+ * 
+ * @author daivanov
+ * 
+ */
+public interface ClassAttributeApprover {
+
+	/**
+	 * Override this method to select or reject class attributes
+	 *
+	 * @param attribute
+	 *        class attribute to analyze for further processing or skipping
+	 * @return
+	 *        true, if attribute should be kept, false, if it should be skipped
+	 */
+	boolean approve(ClassAttribute attribute);
+}

--- a/src/main/java/uk/co/jemos/podam/api/ClassInfo.java
+++ b/src/main/java/uk/co/jemos/podam/api/ClassInfo.java
@@ -4,8 +4,7 @@
 package uk.co.jemos.podam.api;
 
 import java.io.Serializable;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -34,50 +33,27 @@ public class ClassInfo implements Serializable {
 	private final Class<?> className;
 
 	/** The Set of fields belonging to this class */
-	private final Set<String> classFields;
-
-	/** The Set of setters belonging to this class */
-	private final Set<Method> classSetters;
-
-	/** The Set of constructors for this class. */
-	private final Set<Constructor<?>> constructors;
+	private final Set<ClassAttribute> classAttributes = new HashSet<ClassAttribute>();
 
 	/**
 	 * Full constructor
 	 *
 	 * @param className
 	 *            The class name
-	 * @param classFields
-	 *            The set of fields belonging to this class
-	 * @param classSetters
-	 *            The set of setters belonging to this class
-	 *
-	 * @param constructors
-	 *            The set of constructors for this class
+	 * @param classAttributes
+	 *            The collection of attributes belonging to this class
 	 */
-	public ClassInfo(Class<?> className, Set<String> classFields,
-			Set<Method> classSetters, Set<Constructor<?>> constructors) {
+	public ClassInfo(Class<?> className, Collection<ClassAttribute> classAttributes) {
 		super();
 		this.className = className;
-		this.classFields = new HashSet<String>(classFields);
-		this.classSetters = new HashSet<Method>(classSetters);
-		this.constructors = new HashSet<Constructor<?>>(constructors);
+		this.classAttributes.addAll(classAttributes);
 	}
 
 	/**
 	 * @return the classSetters
 	 */
-	public Set<Method> getClassSetters() {
-		return new HashSet<Method>(classSetters);
-	}
-
-	/**
-	 * It returns the constructors for this class.
-	 *
-	 * @return the constructors
-	 */
-	public Set<Constructor<?>> getConstructors() {
-		return constructors;
+	public Set<ClassAttribute> getClassAttributes() {
+		return new HashSet<ClassAttribute>(classAttributes);
 	}
 
 	/**
@@ -87,15 +63,6 @@ public class ClassInfo implements Serializable {
 	 */
 	public Class<?> getClassName() {
 		return className;
-	}
-
-	/**
-	 * It returns the fields for this class.
-	 *
-	 * @return the classFields
-	 */
-	public Set<String> getClassFields() {
-		return new HashSet<String>(classFields);
 	}
 
 	/*
@@ -108,11 +75,9 @@ public class ClassInfo implements Serializable {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result
-				+ (classFields == null ? 0 : classFields.hashCode());
+				+ (classAttributes == null ? 0 : classAttributes.hashCode());
 		result = prime * result
 				+ (className == null ? 0 : className.hashCode());
-		result = prime * result
-				+ (classSetters == null ? 0 : classSetters.hashCode());
 		return result;
 	}
 
@@ -133,11 +98,11 @@ public class ClassInfo implements Serializable {
 			return false;
 		}
 		ClassInfo other = (ClassInfo) obj;
-		if (classFields == null) {
-			if (other.classFields != null) {
+		if (classAttributes == null) {
+			if (other.classAttributes != null) {
 				return false;
 			}
-		} else if (!classFields.equals(other.classFields)) {
+		} else if (!classAttributes.equals(other.classAttributes)) {
 			return false;
 		}
 		if (className == null) {
@@ -145,13 +110,6 @@ public class ClassInfo implements Serializable {
 				return false;
 			}
 		} else if (!className.getName().equals(other.className.getName())) {
-			return false;
-		}
-		if (classSetters == null) {
-			if (other.classSetters != null) {
-				return false;
-			}
-		} else if (!classSetters.equals(other.classSetters)) {
 			return false;
 		}
 		return true;
@@ -165,10 +123,8 @@ public class ClassInfo implements Serializable {
 		StringBuilder builder = new StringBuilder();
 		builder.append("ClassInfo [className=");
 		builder.append(className);
-		builder.append(", classFields=");
-		builder.append(classFields);
-		builder.append(", classSetters=");
-		builder.append(classSetters);
+		builder.append(", classAttributes=");
+		builder.append(classAttributes);
 		builder.append("]");
 		return builder.toString();
 	}

--- a/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
@@ -4,15 +4,17 @@
 package uk.co.jemos.podam.api;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,10 @@ public final class PodamUtils {
 	// ---------------------->> Constants
 
 	private static final int SETTER_IDENTIFIER_LENGTH = 3;
+
+	private static final String GETTER_PREFIX = "get";
+	private static final String GETTER_PREFIX2 = "is";
+
 	/** The application logger. */
 	private static final Logger LOG = LoggerFactory.getLogger(PodamUtils.class);
 
@@ -48,7 +54,9 @@ public final class PodamUtils {
 	 * @return a {@link ClassInfo} object for the given class
 	 */
 	public static ClassInfo getClassInfo(Class<?> clazz) {
-		return getClassInfo(clazz, null, null);
+		return getClassInfo(clazz,
+				new HashSet<Class<? extends Annotation>>(),
+				Collections.<String>emptySet());
 	}
 
 	/**
@@ -67,72 +75,44 @@ public final class PodamUtils {
 			Set<Class<? extends Annotation>> excludeFieldAnnotations,
 			Set<String> excludedFields) {
 
-		Set<String> classFields = getDeclaredInstanceFields(clazz,
-				excludeFieldAnnotations, excludedFields);
-		Set<Method> classSetters = getPojoSetters(clazz, classFields);
-		Constructor<?>[] constructors = clazz.getConstructors();
-		Set<Constructor<?>> constructorsSet = new HashSet<Constructor<?>>(
-				Arrays.asList(constructors));
-		return new ClassInfo(clazz, classFields, classSetters, constructorsSet);
+		Set<Field> classFields = new HashSet<Field>();
+		Set<Method> classGetters = new HashSet<Method>();
+		Set<Method> classSetters = new HashSet<Method>();
+		fillPojoSets(clazz, classFields, classGetters, classSetters, excludeFieldAnnotations, excludedFields);
 
-	}
-
-	/**
-	 * Given a class, it returns a Set of its declared instance field names.
-	 *
-	 * @param clazz
-	 *            The class to analyse to retrieve declared fields
-	 * @return Set of a class declared field names.
-	 */
-	public static Set<String> getDeclaredInstanceFields(Class<?> clazz) {
-		return getDeclaredInstanceFields(clazz, null, null);
-	}
-
-	/**
-	 * Given a class, it returns a Set of its declared instance field names.
-	 *
-	 * @param clazz
-	 *            The class to analyse to retrieve declared fields
-	 * @param excludeAnnotations
-	 *            fields marked with any of the mentioned annotations will be
-	 *            skipped
-	 * @param excludedFields
-	 *            the fields will not be included in the class info
-	 * @return Set of a class declared field names.
-	 */
-	public static Set<String> getDeclaredInstanceFields(Class<?> clazz,
-			Set<Class<? extends Annotation>> excludeAnnotations,
-			Set<String> excludedFields) {
-
-		if (excludeAnnotations == null) {
-			excludeAnnotations = new HashSet<Class<? extends Annotation>>();
-		}
-		excludeAnnotations.add(PodamExclude.class);
-
-		Class<?> workClass = clazz;
-
-		Set<String> classFields = new HashSet<String>();
-
-		while (workClass != null) {
-			Field[] declaredFields = workClass.getDeclaredFields();
-			for (Field field : declaredFields) {
-				// If users wanted to skip this field, we grant their wishes
-				if (containsAnyAnnotation(field, excludeAnnotations)
-						|| (excludedFields != null
-								&& excludedFields.contains(field.getName()))) {
-					continue;
-				}
-				int modifiers = field.getModifiers();
-				if (!Modifier.isStatic(modifiers)) {
-
-					classFields.add(field.getName());
-				}
-
+		Map<String, ClassAttribute> map = new TreeMap<String, ClassAttribute>();
+		for (Field classField : classFields) {
+			if (!containsAnyAnnotation(classField, excludeFieldAnnotations)
+					&& !excludedFields.contains(classField.getName())) {
+				ClassAttribute attribute = new ClassAttribute(classField,
+						Collections.<Method>emptySet(), Collections.<Method>emptySet());
+				map.put(classField.getName(), attribute);
 			}
-			workClass = workClass.getSuperclass();
 		}
 
-		return classFields;
+		for (Method classGetter : classGetters) {
+			String attributeName = extractFieldNameFromGetterMethod(classGetter);
+			if (!containsAnyAnnotation(classGetter, excludeFieldAnnotations)
+					&& !excludedFields.contains(attributeName)) {
+				ClassAttribute attribute = map.get(attributeName);
+				if (attribute != null) {
+					attribute.getRawGetters().add(classGetter);
+				}
+			}
+		}
+
+		for (Method classSetter : classSetters) {
+			String attributeName = extractFieldNameFromSetterMethod(classSetter);
+			if (!containsAnyAnnotation(classSetter, excludeFieldAnnotations)
+					&& !excludedFields.contains(attributeName)) {
+				ClassAttribute attribute = map.get(attributeName);
+				if (attribute != null) {
+					attribute.getRawSetters().add(classSetter);
+				}
+			}
+		}
+
+		return new ClassInfo(clazz, map.values());
 	}
 
 	/**
@@ -159,6 +139,26 @@ public final class PodamUtils {
 	}
 
 	/**
+	 * Checks if the given method has any one of the annotations
+	 *
+	 * @param method
+	 *            the method to check for
+	 * @param annotations
+	 *            the set of annotations to look for in the field
+	 * @return true if the field is marked with any of the given annotations
+	 */
+	private static boolean containsAnyAnnotation(Method method,
+			Set<Class<? extends Annotation>> annotations) {
+
+		for (Class<? extends Annotation> annotation : annotations) {
+			if (method.getAnnotation(annotation) != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * It returns the getter for the given field.
 	 *
 	 * @param field
@@ -172,9 +172,9 @@ public final class PodamUtils {
 		String methodName;
 		if (boolean.class.isAssignableFrom(field.getType())
 				|| Boolean.class.isAssignableFrom(field.getType())) {
-			methodName = "is" + name;
+			methodName = GETTER_PREFIX2 + name;
 		} else {
-			methodName = "get" + name;
+			methodName = GETTER_PREFIX + name;
 		}
 
 		try {
@@ -182,8 +182,8 @@ public final class PodamUtils {
 		} catch (NoSuchMethodException e) {
 			LOG.debug("No getter {}() for field {}[{}]", methodName, field
 					.getDeclaringClass().getName(), field.getName());
-			if (methodName.startsWith("is")) {
-				methodName = "get" + name;
+			if (methodName.startsWith(GETTER_PREFIX2)) {
+				methodName = GETTER_PREFIX + name;
 				try {
 					return field.getDeclaringClass().getMethod(methodName);
 				} catch (NoSuchMethodException e2) {
@@ -198,31 +198,36 @@ public final class PodamUtils {
 
 	/**
 	 * Given a class and a set of class declared fields it returns a Set of
-	 * setters matching the declared fields
+	 * setters, getters and fields defined for this class
 	 * <p>
-	 * If present, a setter method is considered if and only if the
-	 * {@code classFields} argument contains an attribute whose name matches the
-	 * setter, according to JavaBean standards.
+	 * Anything present: setter, getter or field will be recorded as three
+	 * independent sets available for future analysis
 	 * </p>
 	 *
 	 * @param clazz
-	 *            The class to analyse for setters
+	 *            The class to analyze for setters
 	 * @param classFields
-	 *            A Set of field names for which setters are to be found
-	 * @return A Set of setters matching the class declared field names
-	 *
+	 *            The {@link Set} which will be filled with class' fields
+	 * @param classGetters
+	 *            The {@link Set} which will be filled with class' getters
+	 * @param classSetters
+	 *            The {@link Set} which will be filled with class' setters
 	 */
-	public static Set<Method> getPojoSetters(Class<?> clazz,
-			Set<String> classFields) {
+	public static void fillPojoSets(Class<?> clazz, Set<Field> classFields,
+			Set<Method> classGetters, Set<Method> classSetters,
+			Set<Class<? extends Annotation>> excludeAnnotations,
+			Set<String> excludedFields) {
+
+		if (excludeAnnotations == null) {
+			excludeAnnotations = new HashSet<Class<? extends Annotation>>();
+		}
+		excludeAnnotations.add(PodamExclude.class);
 
 		Class<?> workClass = clazz;
-
-		Set<Method> classSetters = new HashSet<Method>();
 
 		while (workClass != null) {
 
 			Method[] declaredMethods = workClass.getDeclaredMethods();
-			String candidateField = null;
 
 			for (Method method : declaredMethods) {
 				/*
@@ -230,20 +235,35 @@ public final class PodamUtils {
 				 * deal with type erasure and they are not type safe. That why
 				 * they should be ignored
 				 */
-				if (!method.isBridge() && method.getName().startsWith("set")
-						&& method.getReturnType().equals(void.class)) {
-					candidateField = extractFieldNameFromSetterMethod(method);
-					if (classFields.contains(candidateField)) {
+				if (!method.isBridge() && !Modifier.isNative(method.getModifiers())) {
+
+					if (method.getName().startsWith("set")
+							&& method.getReturnType().equals(void.class)) {
 						classSetters.add(method);
+					} else if ((method.getName().startsWith(GETTER_PREFIX) || method.getName().startsWith(GETTER_PREFIX2)) &&
+							method.getParameterTypes().length == 0 && !method.getReturnType().equals(void.class)) {
+						classGetters.add(method);
 					}
-
 				}
-
 			}
+
+			Field[] declaredFields = workClass.getDeclaredFields();
+			for (Field field : declaredFields) {
+				// If users wanted to skip this field, we grant their wishes
+				if (containsAnyAnnotation(field, excludeAnnotations)
+						|| (excludedFields != null
+								&& excludedFields.contains(field.getName()))) {
+					continue;
+				}
+				int modifiers = field.getModifiers();
+				if (!Modifier.isStatic(modifiers)) {
+
+					classFields.add(field);
+				}
+			}
+
 			workClass = workClass.getSuperclass();
 		}
-
-		return classSetters;
 	}
 
 	/**
@@ -263,6 +283,38 @@ public final class PodamUtils {
 	public static String extractFieldNameFromSetterMethod(Method method) {
 		String candidateField = null;
 		candidateField = method.getName().substring(SETTER_IDENTIFIER_LENGTH);
+		if (!"".equals(candidateField)) {
+			candidateField = Character.toLowerCase(candidateField.charAt(0))
+					+ candidateField.substring(1);
+		} else {
+			LOG.debug("Encountered method {}. This will be ignored.", method);
+		}
+
+		return candidateField;
+	}
+
+	/**
+	 * Given a getter {@link Method}, it extracts the field name, according to
+	 * JavaBean standards
+	 * <p>
+	 * This method, given a getter method, it returns the corresponding
+	 * attribute name. For example: given getIntField the method would return
+	 * intField; given isBoolField the method would return boolField. The
+	 * correctness of the return value depends on the adherence to JavaBean
+	 * standards.
+	 * </p>
+	 *
+	 * @param method
+	 *            The setter method from which the field name is required
+	 * @return The field name corresponding to the setter
+	 */
+	public static String extractFieldNameFromGetterMethod(Method method) {
+		String candidateField = method.getName();
+		if (candidateField.startsWith(GETTER_PREFIX)) {
+			candidateField = candidateField.substring(GETTER_PREFIX.length());
+		} else if (candidateField.startsWith(GETTER_PREFIX2)) {
+			candidateField = candidateField.substring(GETTER_PREFIX2.length());
+		}
 		if (!"".equals(candidateField)) {
 			candidateField = Character.toLowerCase(candidateField.charAt(0))
 					+ candidateField.substring(1);

--- a/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
@@ -14,6 +14,7 @@ import junit.framework.Assert;
 import org.junit.Test;
 
 import uk.co.jemos.podam.api.ClassAttribute;
+import uk.co.jemos.podam.api.ClassAttributeApprover;
 import uk.co.jemos.podam.api.ClassInfo;
 import uk.co.jemos.podam.api.PodamUtils;
 import uk.co.jemos.podam.test.dto.EmptyTestPojo;
@@ -25,7 +26,7 @@ import uk.co.jemos.podam.test.dto.SimplePojoWithExcludeAnnotationToTestSetters.T
  * @author mtedone
  *
  */
-public class ClassInfoUnitTest {
+public class ClassInfoUnitTest implements ClassAttributeApprover {
 
 	@Test
 	public void testClassInfoWithEmptyPojo() {
@@ -35,7 +36,7 @@ public class ClassInfoUnitTest {
 				EmptyTestPojo.class, attributes);
 
 		ClassInfo actualClassInfo = PodamUtils
-				.getClassInfo(EmptyTestPojo.class);
+				.getClassInfo(EmptyTestPojo.class, this);
 
 		Assert.assertEquals(
 				"The expected and actual ClassInfo objects are not the same",
@@ -47,7 +48,7 @@ public class ClassInfoUnitTest {
 	public void testClassInfoSettersWithSimplePojo() {
 
 		ClassInfo actualClassInfo = PodamUtils
-				.getClassInfo(SimplePojoToTestSetters.class);
+				.getClassInfo(SimplePojoToTestSetters.class, this);
 		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
 		Assert.assertEquals("Class mismatch",
 				SimplePojoToTestSetters.class, actualClassInfo.getClassName());
@@ -85,7 +86,7 @@ public class ClassInfoUnitTest {
 
 		ClassInfo actualClassInfo = PodamUtils.getClassInfo(
 				SimplePojoWithExcludeAnnotationToTestSetters.class,
-				excludeAnnotations, excludeFields);
+				excludeAnnotations, excludeFields, this);
 		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
 		Set<String> attribs = new HashSet<String>();
 		attribs.add("stringField");
@@ -106,5 +107,10 @@ public class ClassInfoUnitTest {
 			Assert.assertEquals("Wrong number of setters " + attribute.getSetters(),
 					1, attribute.getSetters().size());
 		}
+	}
+
+	@Override
+	public boolean approve(ClassAttribute attribute) {
+		return (attribute.getAttribute() != null);
 	}
 }

--- a/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/ClassInfoUnitTest.java
@@ -4,16 +4,16 @@
 package uk.co.jemos.podam.test.unit;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import junit.framework.Assert;
 
 import org.junit.Test;
 
+import uk.co.jemos.podam.api.ClassAttribute;
 import uk.co.jemos.podam.api.ClassInfo;
 import uk.co.jemos.podam.api.PodamUtils;
 import uk.co.jemos.podam.test.dto.EmptyTestPojo;
@@ -30,14 +30,9 @@ public class ClassInfoUnitTest {
 	@Test
 	public void testClassInfoWithEmptyPojo() {
 
-		Set<String> pojoDeclaredFields = new HashSet<String>();
-
-		Set<Method> pojoSetters = new HashSet<Method>();
-
-		Set<Constructor<?>> constructors = new HashSet<Constructor<?>>();
-
-		ClassInfo expectedClassInfo = new ClassInfo(EmptyTestPojo.class,
-				pojoDeclaredFields, pojoSetters, constructors);
+		List<ClassAttribute> attributes = new ArrayList<ClassAttribute>();
+		ClassInfo expectedClassInfo = new ClassInfo(
+				EmptyTestPojo.class, attributes);
 
 		ClassInfo actualClassInfo = PodamUtils
 				.getClassInfo(EmptyTestPojo.class);
@@ -51,30 +46,15 @@ public class ClassInfoUnitTest {
 	@Test
 	public void testClassInfoSettersWithSimplePojo() {
 
-		Set<String> pojoFields = retrievePojoFields();
-
-		Set<Method> pojoSetters = PodamUtils.getPojoSetters(
-				SimplePojoToTestSetters.class, pojoFields);
-
-		Set<Constructor<?>> constructors = retrieveConstructors(SimplePojoToTestSetters.class);
-
-		ClassInfo expectedClassInfo = new ClassInfo(
-				SimplePojoToTestSetters.class, pojoFields, pojoSetters,
-				constructors);
-
 		ClassInfo actualClassInfo = PodamUtils
 				.getClassInfo(SimplePojoToTestSetters.class);
 		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
-		Assert.assertEquals(
-				"The expected and actual ClassInfo objects do not match!",
-				expectedClassInfo, actualClassInfo);
-
-	}
-
-	private Set<Constructor<?>> retrieveConstructors(Class<?> clazz) {
-		Set<Constructor<?>> constructors = new HashSet<Constructor<?>>(
-				Arrays.asList(clazz.getConstructors()));
-		return constructors;
+		Assert.assertEquals("Class mismatch",
+				SimplePojoToTestSetters.class, actualClassInfo.getClassName());
+		Set<String> attribs = new HashSet<String>();
+		attribs.add("stringField");
+		attribs.add("intField");
+		checkAttributes(attribs, actualClassInfo.getClassAttributes());
 	}
 
 	@Test
@@ -103,32 +83,28 @@ public class ClassInfoUnitTest {
 			Set<Class<? extends Annotation>> excludeAnnotations,
 			Set<String> excludeFields) {
 
-		Set<String> pojoFields = retrievePojoFields();
-
-		Set<Method> pojoSetters = PodamUtils.getPojoSetters(
-				SimplePojoWithExcludeAnnotationToTestSetters.class, pojoFields);
-
-		Set<Constructor<?>> constructors = retrieveConstructors(SimplePojoWithExcludeAnnotationToTestSetters.class);
-
-		ClassInfo expectedClassInfo = new ClassInfo(
-				SimplePojoWithExcludeAnnotationToTestSetters.class, pojoFields,
-				pojoSetters, constructors);
 		ClassInfo actualClassInfo = PodamUtils.getClassInfo(
 				SimplePojoWithExcludeAnnotationToTestSetters.class,
 				excludeAnnotations, excludeFields);
 		Assert.assertNotNull("ClassInfo cannot be null!", actualClassInfo);
-		Assert.assertEquals(
-				"The expected and actual ClassInfo objects do not match!",
-				expectedClassInfo, actualClassInfo);
-		Assert.assertEquals("All fields from subclass must be excluded", 2,
-				actualClassInfo.getClassSetters().size());
+		Set<String> attribs = new HashSet<String>();
+		attribs.add("stringField");
+		attribs.add("intField");
+		checkAttributes(attribs, actualClassInfo.getClassAttributes());
 	}
 
-	private Set<String> retrievePojoFields() {
-		Set<String> pojoFields = new HashSet<String>();
-		pojoFields.add("stringField");
-		pojoFields.add("intField");
-		return pojoFields;
+	private void checkAttributes(Set<String> attribs, Set<ClassAttribute> classAttributes) {
+		Assert.assertEquals("Wrong number of attributes" + classAttributes, attribs.size(),
+				classAttributes.size());
+		for (ClassAttribute attribute : classAttributes) {
+			String attrName = attribute.getAttribute().getName();
+			if (!attribs.contains(attrName)) {
+				Assert.fail("Unexpected attribute " + attrName);
+			}
+			Assert.assertEquals("Wrong number of getters " + attribute.getGetters(),
+					1, attribute.getGetters().size());
+			Assert.assertEquals("Wrong number of setters " + attribute.getSetters(),
+					1, attribute.getSetters().size());
+		}
 	}
-
 }


### PR DESCRIPTION
ClassInfoStrategy allows users to customize attribute selection in the POJO:

    ClassInfoStrategy classInfoStrategy = new AbstractClassInfoStrategy() {

	    @Override
	    public boolean approve(ClassAttribute attribute) {
		    // Approves attributes with, which have corresponding field
		    // Any rule could be here
		    return (attribute.getAttribute() != null);
	    }
    }

`ClassInfoStrategy` is registered to `PodamFactory`

    PodamFactory factory = new PodamFactoryImpl().setClassStrategy(classInfoStrategy);

Manufacturing as usual

    Pojo pojo = podam.manufacturePojo(Pojo.class);
