### PR TITLE
Make it possible to exclude fields by name

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractClassInfoStrategy.java
@@ -107,6 +107,27 @@ public abstract class AbstractClassInfoStrategy implements ClassInfoStrategy,
 	}
 
 	/**
+	 * Adds the specified field to set of excluded fields,
+	 * if it is not already present.
+	 *
+	 * @param pojoClass
+	 *        a class for which fields should be skipped
+	 * @param fieldName
+	 *            the field name to use as an exclusion mark
+	 * @return itself
+	 */
+	public AbstractClassInfoStrategy addExcludedField(
+			final Class<?> pojoClass, final String fieldName) {
+		Set<String> fields = excludedFields.get(pojoClass);
+		if (fields == null) {
+			fields = new HashSet<String>();
+			excludedFields.put(pojoClass, fields);
+		}
+		fields.add(fieldName);
+		return this;
+	}
+
+	/**
 	 * Removes the field name from set of excluded fields.
 	 *
 	 * @param pojoClass

--- a/src/test/java/uk/co/jemos/podam/test/dto/BooleanPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/BooleanPojo.java
@@ -15,6 +15,7 @@ public class BooleanPojo {
 	private boolean value1;
 	private Boolean value2;
 	private Boolean value3;
+	private Boolean value4;
 
 	public BooleanPojo() {
 	}
@@ -42,5 +43,13 @@ public class BooleanPojo {
 
 	public void setValue3(Boolean value3) {
 		this.value3 = value3;
+	}
+
+	public Boolean getValue4() {
+		return value4;
+	}
+
+	public void setValue4(Boolean value4) {
+		this.value4 = value4;
 	}
 }

--- a/src/test/java/uk/co/jemos/podam/test/unit/BooleanUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/BooleanUnitTest.java
@@ -34,6 +34,7 @@ public class BooleanUnitTest implements Serializable {
 
 	@BeforeClass
 	public static void init() {
+		classInfoStrategy.addExcludedField(BooleanPojo.class, "value4");
 		classInfoStrategy.addExcludedAnnotation(TestExclude.class);
 		classInfoStrategy.addExcludedAnnotation(PodamExclude.class);
 		Assert.assertEquals("Unexpected number of exluded annotations",
@@ -42,6 +43,7 @@ public class BooleanUnitTest implements Serializable {
 
 	@AfterClass
 	public static void deinit() {
+		classInfoStrategy.removeExcludedField(BooleanPojo.class, "value4");
 		classInfoStrategy.removeExcludedAnnotation(TestExclude.class);
 		Assert.assertEquals("Unexpected number of exluded annotations",
 				1, classInfoStrategy.getExcludedAnnotations().size());
@@ -59,6 +61,8 @@ public class BooleanUnitTest implements Serializable {
 
 		Assert.assertNotNull("Should be filled", pojo.getValue3());
 		Assert.assertEquals("Should be filled", true, pojo.getValue3());
+
+		Assert.assertNull("Should be excluded", pojo.getValue4());
 	}
 
 }


### PR DESCRIPTION
After commit 1c10708 was impossible to exclude fields by name as setter for exclusion names was removed.