### PR TITLE
Fixed exception when a field and its setter's parameter both have annotations

### DIFF
--- a/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamUtils.java
@@ -436,7 +436,7 @@ public final class PodamUtils {
 
 		List<Annotation> retValue;
 		if (annotations != null && annotations.length != 0) {
-			retValue = Arrays.asList(annotations);
+			retValue = new ArrayList<Annotation>(Arrays.asList(annotations));
 		} else {
 			retValue = new ArrayList<Annotation>();
 		}


### PR DESCRIPTION
In the case I see the stack trace:
```
ava.lang.UnsupportedOperationException
    at java.util.AbstractList.add(AbstractList.java:148)
    at java.util.AbstractList.add(AbstractList.java:108)
    at uk.co.jemos.podam.api.PodamUtils.getAttributeAnnotations(PodamUtils.java:444)
    at uk.co.jemos.podam.api.PodamFactoryImpl.populatePojoInternal(PodamFactoryImpl.java:1348)
    at uk.co.jemos.podam.api.PodamFactoryImpl.manufacturePojoInternal(PodamFactoryImpl.java:1249)
    at uk.co.jemos.podam.api.PodamFactoryImpl.manufacturePojo(PodamFactoryImpl.java:175)
```

Here `PodamUtils.getAttributeAnnotations()` creates a non-mutable `List<>` using `Arrays.asList()` and then tries to add an element to the list. *(In depth, `Arrays.asList()` instances private `Arrays.ArrayList<>` without well-defined method `add()`. It's not that public `java.util.ArrayList<>` with full support of modification.)*