### PR TITLE
Issue with resolving parameters of generic types in constructor arguments

### DIFF
--- a/src/test/java/uk/co/jemos/podam/test/dto/GenericsInConstructorPojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/GenericsInConstructorPojo.java
@@ -1,0 +1,33 @@
+package uk.co.jemos.podam.test.dto;
+
+import java.util.Vector;
+
+/**
+ * Generic Pojo with several generic types in constructor
+ *
+ * @author daivanov
+ */
+public class GenericsInConstructorPojo {
+
+	private Vector<?> objVector;
+	private Vector<String> strVector;
+	private Vector<Integer> intVector;
+
+	public GenericsInConstructorPojo(Vector<?> objVector, Vector<String> strVector, Vector<Integer> intVector) {
+		this.objVector = objVector;
+		this.strVector = strVector;
+		this.intVector = intVector;
+	}
+
+	public Vector<?> getObjVector() {
+		return objVector;
+	}
+
+	public Vector<String> getStrVector() {
+		return strVector;
+	}
+
+	public Vector<Integer> getIntVector() {
+		return intVector;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/features/constructors/ConstructorsUnitTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/features/constructors/ConstructorsUnitTest.java
@@ -31,6 +31,19 @@ public class ConstructorsUnitTest extends AbstractPodamSteps {
 		podamValidationSteps.theObjectShouldNotBeNull(pojo);
 		podamValidationSteps.theCollectionShouldNotBeNullOrEmptyAndContainElementsOfType(pojo.getVector(), String.class);
 	}
+
+	@Test
+	@Title("Podam should handle several generics in the constructor")
+	public void podamShouldHandleSeveralGenericsInConstructor() throws Exception {
+		PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+		GenericsInConstructorPojo pojo
+				= podamInvocationSteps.whenIInvokeTheFactoryForClass(GenericsInConstructorPojo.class, podamFactory);
+		podamValidationSteps.theObjectShouldNotBeNull(pojo);
+		podamValidationSteps.theCollectionShouldNotBeNullOrEmptyAndContainElementsOfType(pojo.getObjVector(), Object.class);
+		podamValidationSteps.theCollectionShouldNotBeNullOrEmptyAndContainElementsOfType(pojo.getStrVector(), String.class);
+		podamValidationSteps.theCollectionShouldNotBeNullOrEmptyAndContainElementsOfType(pojo.getIntVector(), Integer.class);
+	}
+
 	@Test
 	@Title("Podam should handle generics in setters during Pojo instantiation")
 	public void podamShouldHandleGenericsInSettersDuringPojoInstantiation() throws Exception {

--- a/src/test/java/uk/co/jemos/podam/test/unit/steps/PodamValidationSteps.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/steps/PodamValidationSteps.java
@@ -1,5 +1,8 @@
 package uk.co.jemos.podam.test.unit.steps;
 
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
 import net.thucydides.core.annotations.Step;
 import org.junit.Assert;
 import org.springframework.util.StringUtils;
@@ -15,13 +18,15 @@ import java.util.concurrent.ConcurrentMap;
 public class PodamValidationSteps {
 
     @Step("Then the Object should not be null")
-    public boolean theObjectShouldNotBeNull(Object pojo) {
-        return pojo == null;
+    public void theObjectShouldNotBeNull(Object pojo) {
+        assertThat(pojo, is(notNullValue()));
     }
 
     @Step("Then the Pojo should contain some data")
-    public boolean thePojoShouldContainSomeData(Object pojo) {
-        return pojo.getClass().getDeclaredFields()[0] != null;
+    public void thePojoShouldContainSomeData(Object pojo) {
+        assertThat(
+                pojo.getClass().getDeclaredFields(),
+                arrayWithSize(greaterThan(0)));
     }
 
     @Step("Then the Pojo should be null")


### PR DESCRIPTION
There is an error in how PODAM resolves generic parameters of types in constructors.
For example for this POJO cannot be instantiated.
There is aslo a bug with validation of non-null objects.