### PR TITLE
Fix javadoc for bound argument in AbstractTypeManufacturer.getInteger

### DIFF
--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/AbstractTypeManufacturer.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/AbstractTypeManufacturer.java
@@ -34,7 +34,7 @@ public abstract class AbstractTypeManufacturer<T> implements TypeManufacturer<T>
     /** It returns a int/Integer value in an interval (0, bound).
 	 *
 	 * @param bound
-	 *            the upper bound (exclusive). Must be positive.
+	 *            the upper bound (inclusive). Must be positive.
 	 * @return A random int value.
 	 */
 	public int getInteger(int bound) {


### PR DESCRIPTION
Actually upper bound is inclusive when calling PodamUtils.getIntegerInRange().
And callers of AbstractTypeManufacturer.getInteger() relies on inclusive bounding.