### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<serenity.version>1.2.2</serenity.version>
 		<spring.version>5.3.13</spring.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<github.global.server>github</github.global.server>


### PR DESCRIPTION
Please refer to the articles below :

- https://snyk.io/blog/new-log4j-2-17-1-fixes-cve-2021-44832-remote-code-execution-but-its-not-as-bad-as-it-sounds/
- https://securityaffairs.co/wordpress/126135/hacking/new-apache-log4j-cve-2021-44832.html