### PR TITLE
Add attribute strategy store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<serenity.version>1.2.2</serenity.version>
+		<serenity.version>3.2.5</serenity.version>
 		<spring.version>5.3.21</spring.version>
 		<log4j.version>2.17.2</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -218,10 +218,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
+					<source>11</source>
+					<target>11</target>
 					<jdkToolchain>
-						<version>6</version>
+						<version>11</version>
 					</jdkToolchain>
-					<target>1.6</target>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -479,6 +481,16 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.12.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<version>3.0.1-b11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.1-jre</version>
+		</dependency>
 
 		<!-- Testing dependencies -->
 		<dependency>
@@ -508,7 +520,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>5.4.3.Final</version>
+			<version>6.0.16.Final</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -558,7 +570,7 @@
 		<profile>
 			<id>doclint-java8</id>
 			<activation>
-				<jdk>[1.8,)</jdk>
+				<jdk>[11,)</jdk>
 			</activation>
 			<properties>
 				<javadoc.opts>-Xdoclint:all</javadoc.opts>

--- a/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
+++ b/src/main/java/uk/co/jemos/podam/api/PodamFactoryImpl.java
@@ -11,11 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.co.jemos.podam.api.DataProviderStrategy.Order;
-import uk.co.jemos.podam.common.AttributeStrategy;
-import uk.co.jemos.podam.common.Holder;
-import uk.co.jemos.podam.common.ManufacturingContext;
-import uk.co.jemos.podam.common.PodamConstants;
-import uk.co.jemos.podam.common.PodamConstructor;
+import uk.co.jemos.podam.common.*;
 import uk.co.jemos.podam.exceptions.PodamMockeryException;
 import uk.co.jemos.podam.typeManufacturers.TypeManufacturerUtil;
 
@@ -803,6 +799,9 @@ public class PodamFactoryImpl implements PodamFactory {
 
 		AttributeStrategy<?> attributeStrategy
 				= TypeManufacturerUtil.findAttributeStrategy(strategy, pojoAttributeAnnotations, attributeType);
+		if (null == attributeStrategy) {
+			attributeStrategy = AttributeStrategyStore.geAttributeStrategy(pojo.getClass(), attribute.getName());
+		}
 		Object setterArg = null;
 		if (null != attributeStrategy) {
 

--- a/src/main/java/uk/co/jemos/podam/common/AttributeStrategyStore.java
+++ b/src/main/java/uk/co/jemos/podam/common/AttributeStrategyStore.java
@@ -1,0 +1,28 @@
+package uk.co.jemos.podam.common;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+public class AttributeStrategyStore {
+
+    private AttributeStrategyStore(){}
+
+    private static final Table<Class<?>, String, AttributeStrategy<?>> attributeStrategyTable = HashBasedTable.create();
+
+
+    public static void setAttributeStrategyForField(Class<?> clazz, String fieldName, AttributeStrategy<?> attributeStrategy) {
+        attributeStrategyTable.put(clazz, fieldName, attributeStrategy);
+    }
+
+    public static void deleteAttributeStrategyForField(Class<?> clazz, String fieldName, AttributeStrategy<?> attributeStrategy) {
+        attributeStrategyTable.remove(clazz, fieldName);
+    }
+
+    public static Table<Class<?>, String, AttributeStrategy<?>> getStore() {
+        return attributeStrategyTable;
+    }
+
+    public static AttributeStrategy<?> geAttributeStrategy(Class<?> clazz, String fieldName) {
+        return attributeStrategyTable.get(clazz, fieldName);
+    }
+}


### PR DESCRIPTION
**Abstract**
AttributeStrategyStore helps add AttributeStrategy without adding annotation @PodamStrategyValue. This is needed for existing classes from the library, which required specify value for return. 

For example:                                                        
`AttributeStrategyStore.setAttributeStrategyForField(Test.class, "name", new PostCodeStrategy());
`

Need specify: class, field name and strategy

Sorry if I didn't see an existing way to specify values ​​for library classes, then please close PR.

If that PR make sense, I'll continue develop (adding: tests: javadoc ...).

Please consider my request.

Best regards,
Nikita Kochkurov