### PR TITLE
java.lang.CharSequence is missing in uk.co.jemos.podam.typeManufacturers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,13 +216,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.10.1</version>
 				<configuration>
 					<jdkToolchain>
-						<version>6</version>
+						<version>7</version>
 					</jdkToolchain>
-					<target>1.6</target>
-				</configuration>
+                    <target>7</target>s
+                    <source>7</source>
+                </configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/CharSequenceTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/CharSequenceTypeManufacturerImpl.java
@@ -1,0 +1,86 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.PodamConstants;
+import uk.co.jemos.podam.common.PodamStringValue;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Default String type manufacturer.
+ *
+ * Created by tedonema on 17/05/2015.
+ *
+ * @since 6.0.0.RELEASE
+ */
+public class CharSequenceTypeManufacturerImpl extends AbstractTypeManufacturer<CharSequence> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType(DataProviderStrategy strategy,
+            AttributeMetadata attributeMetadata,
+            Map<String, Type> genericTypesArgumentsMap) {
+
+        String retValue;
+
+        PodamStringValue annotationStrategy = findElementOfType(
+                attributeMetadata.getAttributeAnnotations(), PodamStringValue.class);
+
+            retValue = getStringValue(attributeMetadata);
+
+        if (null != annotationStrategy) {
+
+            retValue = annotationStrategy.strValue();
+            if (StringUtils.isEmpty(retValue)) {
+
+                retValue = getStringOfLength(
+                        annotationStrategy.length(), attributeMetadata);
+            }
+        } else {
+            retValue = getStringValue(attributeMetadata);
+        }
+
+        return retValue;
+    }
+
+	/** It returns a string value
+	 * 
+	 * @param attributeMetadata
+	 *            attribute metadata for instance to be fetched
+	 * @return A String of default length
+	 */
+	public String getStringValue(AttributeMetadata attributeMetadata) {
+
+		return getStringOfLength(PodamConstants.STR_DEFAULT_LENGTH,
+				attributeMetadata);
+	}
+
+	/**
+	 * It returns a String of {@code length} characters.
+	 * 
+	 * @param length
+	 *            The number of characters required in the returned String
+	 * @param attributeMetadata
+	 *            attribute metadata for instance to be fetched
+	 * @return A String of {@code length} characters
+	 */
+	public String getStringOfLength(int length,
+			AttributeMetadata attributeMetadata) {
+
+		StringBuilder buff = new StringBuilder();
+
+		while (buff.length() < length) {
+			buff.append(PodamUtils.getNiceCharacter());
+		}
+
+		return buff.toString();
+	}
+
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/CharSequenceTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/CharSequenceTypeManufacturerImpl.java
@@ -12,11 +12,11 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * Default String type manufacturer.
+ * Default CharSequence type manufacturer.
  *
- * Created by tedonema on 17/05/2015.
+ * Created by m.maatkamp@gmail.com on 20/10/2022.
  *
- * @since 6.0.0.RELEASE
+ * @since 7.2.11.RELEASE
  */
 public class CharSequenceTypeManufacturerImpl extends AbstractTypeManufacturer<CharSequence> {
 

--- a/src/test/java/uk/co/jemos/podam/test/dto/CharSequencePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/CharSequencePojo.java
@@ -1,0 +1,22 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto;
+
+/**
+ * POJO to test when Podam sets signle letter fields with number.
+ *
+ * @author daivanov
+ *
+ */
+public class CharSequencePojo {
+	private CharSequence v1;
+
+	public CharSequence getV1() {
+		return v1;
+	}
+
+	public void setV1(CharSequence v1) {
+		this.v1 = v1;
+	}
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/features/classInfo/ClassInfoTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/features/classInfo/ClassInfoTest.java
@@ -10,11 +10,7 @@ import uk.co.jemos.podam.api.AbstractClassInfoStrategy;
 import uk.co.jemos.podam.api.ClassAttribute;
 import uk.co.jemos.podam.api.ClassAttributeApprover;
 import uk.co.jemos.podam.api.ClassInfo;
-import uk.co.jemos.podam.test.dto.EmptyTestPojo;
-import uk.co.jemos.podam.test.dto.NonStandardPojoToTestSetters;
-import uk.co.jemos.podam.test.dto.ShortNamesPojo;
-import uk.co.jemos.podam.test.dto.SimplePojoToTestSetters;
-import uk.co.jemos.podam.test.dto.SimplePojoWithExcludeAnnotationToTestSetters;
+import uk.co.jemos.podam.test.dto.*;
 import uk.co.jemos.podam.test.unit.AbstractPodamSteps;
 
 import java.lang.annotation.Annotation;
@@ -68,6 +64,19 @@ public class ClassInfoTest extends AbstractPodamSteps {
         ClassInfo actualClassInfo = podamInvocationSteps.getClassInfo(ShortNamesPojo.class, nullApprover);
         podamValidationSteps.theObjectShouldNotBeNull(actualClassInfo);
         podamValidationSteps.theTwoObjectsShouldBeEqual(ShortNamesPojo.class, actualClassInfo.getClassName());
+        Set<String> attribs = new HashSet<String>();
+        attribs.add("v1");
+        classInfoValidationSteps.theClassInfoAttributesShouldMatchthePojoOnes(attribs, actualClassInfo.getClassAttributes());
+
+    }
+
+    public void podamShouldReturnACharSequenceObjectWithSingleLetterAndNumberAtrributes() {
+
+        ClassAttributeApprover nullApprover = null;
+
+        ClassInfo actualClassInfo = podamInvocationSteps.getClassInfo(CharSequencePojo.class, nullApprover);
+        podamValidationSteps.theObjectShouldNotBeNull(actualClassInfo);
+        podamValidationSteps.theTwoObjectsShouldBeEqual(CharSequencePojo.class, actualClassInfo.getClassName());
         Set<String> attribs = new HashSet<String>();
         attribs.add("v1");
         classInfoValidationSteps.theClassInfoAttributesShouldMatchthePojoOnes(attribs, actualClassInfo.getClassAttributes());


### PR DESCRIPTION
Apache Avro uses CharSequence for string-type attributes when (de-)serializing java pojo's. Testing these with Podam requires a 'CharSequenceTypeManufacturer' which is currently missing:

```WARN  u.c.jemos.podam.api.PodamFactoryImpl - Cannot instantiate a class interface java.lang.CharSequence. Resorting to uk.co.jemos.podam.api.NullExternalFactory external factory```

I have implemented CharSequenceTypeManufacturer and a added a test-case. I also had to bump compiler.source to '7' in order to succesfully compile the code.