### PR TITLE
Modify support for java.time.* and annotation @Future, @FutureOrPresent, @PastOrPresent and @Past classes for Issue #323

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>7</version>
+		<version>9</version>
 	</parent>
 
 	<groupId>uk.co.jemos.podam</groupId>
@@ -185,6 +185,13 @@
 				<role>Developer</role>
 			</roles>
 		</contributor>
+		<contributor>
+			<name>Liam KINCAID</name>
+			<email>liam.kincaid@free.fr</email>
+			<roles>
+				<role>Developer</role>
+			</roles>
+		</contributor>
 	</contributors>
 
 
@@ -226,10 +233,10 @@
 				<version>3.10.1</version>
 				<configuration>
 					<jdkToolchain>
-						<version>7</version>
+						<version>8</version>
 					</jdkToolchain>
-                    <target>7</target>s
-                    <source>7</source>
+                    <target>8</target>
+                    <source>8</source>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>

--- a/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/api/AbstractRandomDataProviderStrategy.java
@@ -10,29 +10,17 @@ import org.slf4j.LoggerFactory;
 
 import uk.co.jemos.podam.common.*;
 import uk.co.jemos.podam.exceptions.PodamMockeryException;
-import uk.co.jemos.podam.typeManufacturers.ArrayTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.BooleanTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.ByteTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.CharTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.CollectionTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.DoubleTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.EnumTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.FloatTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.IntTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.LongTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.MapTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.ShortTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.StringTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.TypeTypeManufacturerImpl;
-import uk.co.jemos.podam.typeManufacturers.TypeManufacturer;
+import uk.co.jemos.podam.typeManufacturers.*;
 
-import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.time.*;
+import java.time.temporal.Temporal;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
@@ -196,8 +184,40 @@ public abstract class AbstractRandomDataProviderStrategy implements RandomDataPr
 
 		TypeManufacturer<?> arrayManufacturer = new ArrayTypeManufacturerImpl();
 		typeManufacturers.put(Cloneable.class, arrayManufacturer);
-
+		
+        /**
+         * Support of classes with annotation strategy:
+         * - {@link java.time.Duration}
+         * - {@link java.time.ZoneId}
+         * - {@link java.time.ZoneOffset}
+         */
+		addOrReplaceTypeManufacturer(Duration.class, new DurationTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(MonthDay.class, new MonthDayTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(Period.class, new PeriodTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(ZoneId.class, new ZoneIdTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(ZoneOffset.class, new ZoneOffsetTypeManufacturerImpl());
+        
+		/**
+         * Support of {@link java.time.Temporal} classes with annotation strategy:
+         * - {@link jakarta.validation.constraint.Future}
+         * - {@link jakarta.validation.constraint.FutureOfPresent}
+         * - {@link jakarta.validation.constraint.PastOfPresent}
+         * - {@link jakarta.validation.constraint.Past}
+         */
+		addOrReplaceTypeManufacturer(Clock.class, new ClockTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(Instant.class, new InstantTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(LocalDate.class, new LocalDateTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(LocalDateTime.class, new LocalDateTimeTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(LocalTime.class, new LocalTimeTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(OffsetDateTime.class, new OffsetDateTimeTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(OffsetTime.class, new OffsetTimeTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(Year.class, new YearTypeManufacturerImpl());
+		addOrReplaceTypeManufacturer(ZonedDateTime.class, new ZonedDateTimeTypeManufacturerImpl());
         addOrReplaceAttributeStrategy(Email.class, new EmailStrategy());
+        addOrReplaceAttributeStrategy(Future.class, new FutureStrategy());
+        addOrReplaceAttributeStrategy(FutureOrPresent.class, new FutureOrPresentStrategy());
+        addOrReplaceAttributeStrategy(PastOrPresent.class, new PastOrPresentStrategy());
+        addOrReplaceAttributeStrategy(Past.class, new PastStrategy());
 	}
 
 	// ------------------->> Public methods

--- a/src/main/java/uk/co/jemos/podam/common/CommonTypeOrStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/common/CommonTypeOrStrategy.java
@@ -1,0 +1,115 @@
+package uk.co.jemos.podam.common;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+import java.lang.annotation.Annotation;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.PodamUtils;
+
+/**
+ * Base {@link java.time.temporal.Temporal} type strategy.
+ *
+ * @author liam on 03/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public interface CommonTypeOrStrategy {
+
+    /**
+     * It returns an {@link java.time.ZoneId} value.
+     *
+     * @return A {@link java.time.ZoneId} value
+     */
+    default ZoneId getZoneId() {
+        Set<String> zoneIds = ZoneId.getAvailableZoneIds();
+        Integer index = PodamUtils.getIntegerInRange(0, zoneIds.size());
+
+        int i = 0;
+        for (String zoneId : zoneIds) {
+            if (index.equals(i++)) {
+                return ZoneId.of(zoneId);
+            }
+        }
+
+        return ZoneId.systemDefault();
+    }
+
+    /**
+     * Calculate a couple of seconds and nanoseconds
+     *
+     * @param annotations list of annotations attached to an attribute
+     * @param seconds     A amount a seconds
+     * @param nanos       A amoutn of nanoseconds
+     */
+    default void getSecondsNanos(List<Annotation> annotations, AtomicReference<Long> seconds, AtomicReference<Long> nanos) {
+
+        Instant now = Instant.now();
+
+        if (annotations.stream().anyMatch(Future.class::isInstance)) {
+
+            Instant futur = now.plus(1L, ChronoUnit.DAYS);
+            seconds.set(PodamUtils.getLongInRange(futur.getEpochSecond(), Instant.MAX.getEpochSecond()));
+
+        } else if (annotations.stream().anyMatch(FutureOrPresent.class::isInstance)) {
+
+            seconds.set(PodamUtils.getLongInRange(now.getEpochSecond(), Instant.MAX.getEpochSecond()));
+
+        } else if (annotations.stream().anyMatch(PastOrPresent.class::isInstance)) {
+
+            seconds.set(PodamUtils.getLongInRange(Instant.MIN.getEpochSecond(), now.getEpochSecond()));
+
+        } else if (annotations.stream().anyMatch(Past.class::isInstance)) {
+
+            Instant past = now.minus(1L, ChronoUnit.DAYS);
+            seconds.set(PodamUtils.getLongInRange(Instant.MIN.getEpochSecond(), past.getEpochSecond()));
+
+        } else {
+
+            seconds.set(PodamUtils.getLongInRange(Instant.MIN.getEpochSecond(), Instant.MAX.getEpochSecond()));
+        }
+
+        nanos.set(PodamUtils.getLongInRange(Instant.MIN.getNano(), Instant.MAX.getNano()));
+    }
+
+    /**
+     * Calculate a couple of years
+     *
+     * @param annotations list of annotations attached to an attribute
+     * @param years       A amount a year
+     */
+    default void getYearsMonthsDays(List<Annotation> annotations, AtomicReference<Integer> years, AtomicReference<Integer> months, AtomicReference<Integer> days) {
+
+        YearMonth now = YearMonth.now();
+
+        if (annotations.stream().anyMatch(Future.class::isInstance)) {
+
+            YearMonth futur = now.plusMonths(6L);
+            years.set(PodamUtils.getIntegerInRange(futur.getYear(), Year.MAX_VALUE));
+
+        } else if (annotations.stream().anyMatch(FutureOrPresent.class::isInstance)) {
+
+            years.set(PodamUtils.getIntegerInRange(now.getYear(), Year.MAX_VALUE));
+
+        } else if (annotations.stream().anyMatch(PastOrPresent.class::isInstance)) {
+
+            years.set(PodamUtils.getIntegerInRange(Year.MIN_VALUE, now.getYear()));
+
+        } else if (annotations.stream().anyMatch(Past.class::isInstance)) {
+
+            YearMonth past = now.minusMonths(6L);
+            years.set(PodamUtils.getIntegerInRange(Year.MIN_VALUE, past.getYear()));
+
+        } else {
+
+            years.set(PodamUtils.getIntegerInRange(Year.MIN_VALUE, Year.MAX_VALUE));
+        }
+
+        months.set(PodamUtils.getIntegerInRange(1, 12));
+        days.set(PodamUtils.getIntegerInRange(1, YearMonth.of(years.get(), months.get()).atEndOfMonth().getDayOfMonth()));
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/common/FutureOrPresentStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/common/FutureOrPresentStrategy.java
@@ -1,0 +1,94 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Annotation;
+import java.time.*;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+/**
+ * This strategy fills {@link jakarta.validation.constraints.FutureOrPresent}
+ * attributes and parameters annotated with Java bean validation annotations
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+public class FutureOrPresentStrategy implements AttributeStrategy<Temporal>, CommonTypeOrStrategy {
+
+    /**
+     * Constructor for the strategy
+     */
+    public FutureOrPresentStrategy() {
+    	super();
+    }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public Temporal getValue(Class<?> attrType, List<Annotation> annotations) throws PodamMockeryException {
+
+		AtomicReference<Long> seconds = new AtomicReference<>();
+		AtomicReference<Long> nanos = new AtomicReference<>();
+
+		getSecondsNanos(annotations, seconds, nanos);
+
+		if (Instant.class.isAssignableFrom(attrType)) {
+
+			return Instant.ofEpochSecond(seconds.get(), nanos.get());
+		}
+
+		Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+		if (LocalDateTime.class.isAssignableFrom(attrType)) {
+
+			return LocalDateTime.ofInstant(instant, getZoneId());
+		}
+
+		if (LocalDate.class.isAssignableFrom(attrType)) {
+
+			return LocalDateTime.ofInstant(instant, getZoneId()).toLocalDate();
+		}
+
+		if (LocalTime.class.isAssignableFrom(attrType)) {
+
+			return LocalDateTime.ofInstant(instant, getZoneId()).toLocalTime();
+		}
+
+		if (OffsetDateTime.class.isAssignableFrom(attrType)) {
+
+			return OffsetDateTime.ofInstant(instant, getZoneId());
+		}
+
+		if (OffsetTime.class.isAssignableFrom(attrType)) {
+
+			return OffsetTime.ofInstant(instant, getZoneId());
+		}
+
+		if (ZonedDateTime.class.isAssignableFrom(attrType)) {
+
+			return ZonedDateTime.ofInstant(instant, getZoneId());
+		}
+
+		AtomicReference<Integer> years = new AtomicReference<>();
+		AtomicReference<Integer> months = new AtomicReference<>();
+		AtomicReference<Integer> days = new AtomicReference<>();
+
+		getYearsMonthsDays(annotations, years, months, days);
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			return Year.of(years.get());
+		}
+
+		if (YearMonth.class.isAssignableFrom(attrType)) {
+
+			return YearMonth.of(years.get(), months.get());
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/uk/co/jemos/podam/common/FutureStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/common/FutureStrategy.java
@@ -1,0 +1,105 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Annotation;
+import java.time.*;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+/**
+ * This strategy fills {@link jakarta.validation.constraints.Future} attributes
+ * and parameters annotated with Java bean validation annotations
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+public class FutureStrategy implements AttributeStrategy<Temporal>, CommonTypeOrStrategy {
+
+    /**
+     * Constructor for the strategy
+     */
+    public FutureStrategy() {
+    	super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Temporal getValue(Class<?> attrType, List<Annotation> annotations) throws PodamMockeryException {
+
+    	AtomicReference<Long> seconds = new AtomicReference<>();
+    	AtomicReference<Long> nanos = new AtomicReference<>();
+        
+        getSecondsNanos(annotations, seconds, nanos);
+        
+		if (Instant.class.isAssignableFrom(attrType)) {
+			
+	        return Instant.ofEpochSecond(seconds.get(), nanos.get());	        
+		}
+		
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+		if (LocalDateTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (LocalDate.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalDate();
+		}
+		
+		if (LocalTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalTime();
+		}
+		
+		if (OffsetDateTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (OffsetTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetTime.ofInstant(instant, getZoneId());
+		}
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			AtomicReference<Integer> years = new AtomicReference<>();
+			AtomicReference<Integer> months = new AtomicReference<>();
+			AtomicReference<Integer> days = new AtomicReference<>();
+
+			getYearsMonthsDays(annotations, years, months, days);
+
+			return Year.of(years.get());
+		}
+
+		if (ZonedDateTime.class.isAssignableFrom(attrType)) {
+
+			return ZonedDateTime.ofInstant(instant, getZoneId());
+		}
+
+		AtomicReference<Integer> years = new AtomicReference<>();
+		AtomicReference<Integer> months = new AtomicReference<>();
+		AtomicReference<Integer> days = new AtomicReference<>();
+
+		getYearsMonthsDays(annotations, years, months, days);
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			return Year.of(years.get());
+		}
+
+		if (YearMonth.class.isAssignableFrom(attrType)) {
+
+			return YearMonth.of(years.get(), months.get());
+		}
+
+		return null;
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/common/PastOrPresentStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/common/PastOrPresentStrategy.java
@@ -1,0 +1,105 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Annotation;
+import java.time.*;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+/**
+ * This strategy fills {@link jakarta.validation.constraints.PastOrPresent}
+ * attributes and parameters annotated with Java bean validation annotations
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+public class PastOrPresentStrategy implements AttributeStrategy<Temporal>, CommonTypeOrStrategy {
+
+    /**
+     * Constructor for the strategy
+     */
+    public PastOrPresentStrategy() {
+    	super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Temporal getValue(Class<?> attrType, List<Annotation> annotations) throws PodamMockeryException {
+
+    	AtomicReference<Long> seconds = new AtomicReference<>();
+    	AtomicReference<Long> nanos = new AtomicReference<>();
+        
+        getSecondsNanos(annotations, seconds, nanos);
+        
+		if (Instant.class.isAssignableFrom(attrType)) {
+			
+	        return Instant.ofEpochSecond(seconds.get(), nanos.get());	        
+		}
+		
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+		if (LocalDateTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (LocalDate.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalDate();
+		}
+		
+		if (LocalTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalTime();
+		}
+		
+		if (OffsetDateTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (OffsetTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetTime.ofInstant(instant, getZoneId());
+		}
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			AtomicReference<Integer> years = new AtomicReference<>();
+			AtomicReference<Integer> months = new AtomicReference<>();
+			AtomicReference<Integer> days = new AtomicReference<>();
+
+			getYearsMonthsDays(annotations, years, months, days);
+
+			return Year.of(years.get());
+		}
+
+		if (ZonedDateTime.class.isAssignableFrom(attrType)) {
+
+			return ZonedDateTime.ofInstant(instant, getZoneId());
+		}
+
+		AtomicReference<Integer> years = new AtomicReference<>();
+		AtomicReference<Integer> months = new AtomicReference<>();
+		AtomicReference<Integer> days = new AtomicReference<>();
+
+		getYearsMonthsDays(annotations, years, months, days);
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			return Year.of(years.get());
+		}
+
+		if (YearMonth.class.isAssignableFrom(attrType)) {
+
+			return YearMonth.of(years.get(), months.get());
+		}
+
+		return null;
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/common/PastStrategy.java
+++ b/src/main/java/uk/co/jemos/podam/common/PastStrategy.java
@@ -1,0 +1,105 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Annotation;
+import java.time.*;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.exceptions.PodamMockeryException;
+
+/**
+ * This strategy fills {@link jakarta.validation.constraints.Past} attributes
+ * and parameters annotated with Java bean validation annotations
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+public class PastStrategy implements AttributeStrategy<Temporal>, CommonTypeOrStrategy {
+
+    /**
+     * Constructor for the strategy
+     */
+    public PastStrategy() {
+    	super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Temporal getValue(Class<?> attrType, List<Annotation> annotations) throws PodamMockeryException {
+
+    	AtomicReference<Long> seconds = new AtomicReference<>();
+    	AtomicReference<Long> nanos = new AtomicReference<>();
+        
+        getSecondsNanos(annotations, seconds, nanos);
+        
+		if (Instant.class.isAssignableFrom(attrType)) {
+			
+	        return Instant.ofEpochSecond(seconds.get(), nanos.get());	        
+		}
+		
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+		if (LocalDateTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (LocalDate.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalDate();
+		}
+		
+		if (LocalTime.class.isAssignableFrom(attrType)) {
+
+	        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalTime();
+		}
+		
+		if (OffsetDateTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetDateTime.ofInstant(instant, getZoneId());
+		}
+		
+		if (OffsetTime.class.isAssignableFrom(attrType)) {
+
+	        return OffsetTime.ofInstant(instant, getZoneId());
+		}
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			AtomicReference<Integer> years = new AtomicReference<>();
+			AtomicReference<Integer> months = new AtomicReference<>();
+			AtomicReference<Integer> days = new AtomicReference<>();
+
+			getYearsMonthsDays(annotations, years, months, days);
+
+			return Year.of(years.get());
+		}
+
+		if (ZonedDateTime.class.isAssignableFrom(attrType)) {
+
+			return ZonedDateTime.ofInstant(instant, getZoneId());
+		}
+
+		AtomicReference<Integer> years = new AtomicReference<>();
+		AtomicReference<Integer> months = new AtomicReference<>();
+		AtomicReference<Integer> days = new AtomicReference<>();
+
+		getYearsMonthsDays(annotations, years, months, days);
+
+		if (Year.class.isAssignableFrom(attrType)) {
+
+			return Year.of(years.get());
+		}
+
+		if (YearMonth.class.isAssignableFrom(attrType)) {
+
+			return YearMonth.of(years.get(), months.get());
+		}
+
+		return null;
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/common/PodamClockValue.java
+++ b/src/main/java/uk/co/jemos/podam/common/PodamClockValue.java
@@ -1,0 +1,28 @@
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation used to customise min and max values of a {@link java.time.Clock} type attribute or
+ * constructor parameter.
+ *
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+@Documented
+@PodamAnnotation
+@Target({FIELD, METHOD, PARAMETER})
+@Retention(RUNTIME)
+public @interface PodamClockValue {
+    String zoneId() default "";
+
+    String comment() default "";
+}

--- a/src/main/java/uk/co/jemos/podam/common/PodamZoneIdValue.java
+++ b/src/main/java/uk/co/jemos/podam/common/PodamZoneIdValue.java
@@ -1,0 +1,30 @@
+package uk.co.jemos.podam.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation used to customise min and max values of a {@link java.time.ZoneId} type attribute or
+ * constructor parameter.
+ *
+ *
+ * @author liam
+ * @since 8.0.1.RELEASE
+ */
+@Documented
+@PodamAnnotation
+@Target({FIELD, METHOD, PARAMETER})
+@Retention(RUNTIME)
+public @interface PodamZoneIdValue {
+    String zoneId() default "";
+
+    String comment() default "";
+
+    String value() default "";
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/ClockTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/ClockTypeManufacturerImpl.java
@@ -1,0 +1,34 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+import uk.co.jemos.podam.common.PodamClockValue;
+
+import static java.util.Objects.nonNull;
+
+/**
+ * Default {@link java.time.Clock} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ClockTypeManufacturerImpl extends AbstractTypeManufacturer<Clock> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Clock getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+    	PodamClockValue annotationStrategy = findElementOfType(attributeMetadata.getAttributeAnnotations(), PodamClockValue.class);
+        if (nonNull(annotationStrategy)) {
+        	
+        	return Clock.system(ZoneId.of(annotationStrategy.zoneId()));
+        }
+
+    	return Clock.system(getZoneId());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/DurationTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/DurationTypeManufacturerImpl.java
@@ -1,0 +1,31 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.Duration} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class DurationTypeManufacturerImpl extends AbstractTypeManufacturer<Duration> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Duration getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        return Duration.ofSeconds(seconds.get(), nanos.get());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/InstantTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/InstantTypeManufacturerImpl.java
@@ -1,0 +1,30 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.Instant} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class InstantTypeManufacturerImpl extends AbstractTypeManufacturer<Instant> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Instant  getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        return Instant.ofEpochSecond(seconds.get(), nanos.get());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalDateTimeTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalDateTimeTypeManufacturerImpl.java
@@ -1,0 +1,33 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.LocalDateTime} type manufacturer.
+ *
+ * @author by liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalDateTimeTypeManufacturerImpl extends AbstractTypeManufacturer<LocalDateTime> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LocalDateTime getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+        return LocalDateTime.ofInstant(instant, getZoneId());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalDateTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalDateTypeManufacturerImpl.java
@@ -1,0 +1,35 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.LocalDate} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalDateTypeManufacturerImpl extends AbstractTypeManufacturer<LocalDate> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LocalDate getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalDate();
+    }
+}
+

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalTimeTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/LocalTimeTypeManufacturerImpl.java
@@ -1,0 +1,32 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.LocalTime} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalTimeTypeManufacturerImpl extends AbstractTypeManufacturer<LocalTime> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LocalTime getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        long seconds = PodamUtils.getLongInRange(Instant.MIN.getEpochSecond(), Instant.MAX.getEpochSecond());
+        long nanos = PodamUtils.getLongInRange(Instant.MIN.getNano(), Instant.MAX.getNano());
+
+        Instant instant = Instant.ofEpochSecond(seconds, nanos);
+
+        return LocalDateTime.ofInstant(instant, getZoneId()).toLocalTime();
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/MonthDayTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/MonthDayTypeManufacturerImpl.java
@@ -1,0 +1,32 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+import java.time.MonthDay;
+import java.time.Year;
+import java.time.YearMonth;
+
+/**
+ * Default {@link MonthDay} type manufacturer.
+ *
+ * @author liam on 04/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class MonthDayTypeManufacturerImpl extends AbstractTypeManufacturer<MonthDay> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MonthDay getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+    	int years = PodamUtils.getIntegerInRange(Year.MIN_VALUE, Year.MAX_VALUE);
+    	int months = PodamUtils.getIntegerInRange(1, 12);
+        int days = PodamUtils.getIntegerInRange(1, YearMonth.of(years, months).atEndOfMonth().getDayOfMonth());
+
+        return MonthDay.of(months, days);
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/OffsetDateTimeTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/OffsetDateTimeTypeManufacturerImpl.java
@@ -1,0 +1,33 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.OffsetDateTime} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class OffsetDateTimeTypeManufacturerImpl extends AbstractTypeManufacturer<OffsetDateTime> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OffsetDateTime getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+        return OffsetDateTime.ofInstant(instant, getZoneId());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/OffsetTimeTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/OffsetTimeTypeManufacturerImpl.java
@@ -1,0 +1,31 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.OffsetTime;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.OffsetTime} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class OffsetTimeTypeManufacturerImpl extends AbstractTypeManufacturer<OffsetTime> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OffsetTime getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        long seconds = PodamUtils.getLongInRange(Instant.MIN.getEpochSecond(), Instant.MAX.getEpochSecond());
+        long nanos = PodamUtils.getLongInRange(Instant.MIN.getNano(), Instant.MAX.getNano());
+
+        Instant instant = Instant.ofEpochSecond(seconds, nanos);
+
+        return OffsetTime.ofInstant(instant, getZoneId());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/PeriodTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/PeriodTypeManufacturerImpl.java
@@ -1,0 +1,30 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.*;
+
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.Period} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class PeriodTypeManufacturerImpl extends AbstractTypeManufacturer<Period> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Period getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        int years = PodamUtils.getIntegerInRange(Year.MIN_VALUE, Year.MAX_VALUE);
+        int months = PodamUtils.getIntegerInRange(1, 12);
+        int days = PodamUtils.getIntegerInRange(1, YearMonth.of(years, months).atEndOfMonth().getDayOfMonth());
+    	
+        return Period.of(years, months, days);
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/TypeManufacturerUtil.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/TypeManufacturerUtil.java
@@ -1,24 +1,21 @@
 package uk.co.jemos.podam.typeManufacturers;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import uk.co.jemos.podam.api.DataProviderStrategy;
-import uk.co.jemos.podam.api.ObjectStrategy;
-import uk.co.jemos.podam.api.PodamUtils;
-import uk.co.jemos.podam.common.*;
-
 import jakarta.validation.Constraint;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.ObjectStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.*;
 
 /**
  * Type Manufacturer utility class.

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/YearMonthTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/YearMonthTypeManufacturerImpl.java
@@ -1,0 +1,32 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+import java.time.YearMonth;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Default {@link YearMonth} type manufacturer.
+ *
+ * @author liam on 04/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class YearMonthTypeManufacturerImpl extends AbstractTypeManufacturer<YearMonth> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public YearMonth getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Integer> years = new AtomicReference<>();
+        AtomicReference<Integer> months = new AtomicReference<>();
+        AtomicReference<Integer> days = new AtomicReference<>();
+
+        getYearsMonthsDays(attributeMetadata.getAttributeAnnotations(), years, months, days);
+
+        return YearMonth.of(years.get(), months.get());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/YearTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/YearTypeManufacturerImpl.java
@@ -1,0 +1,31 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Year;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.Year} type manufacturer.
+ *
+ * @author liam on 04/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class YearTypeManufacturerImpl extends AbstractTypeManufacturer<Year> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Year getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Integer> years = new AtomicReference<>();
+        AtomicReference<Integer> months = new AtomicReference<>();
+        AtomicReference<Integer> days = new AtomicReference<>();
+
+        getYearsMonthsDays(attributeMetadata.getAttributeAnnotations(), years, months, days);
+
+        return Year.of(years.get());
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/ZoneIdTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/ZoneIdTypeManufacturerImpl.java
@@ -1,0 +1,24 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.ZoneId;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.ZoneId} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZoneIdTypeManufacturerImpl extends AbstractTypeManufacturer<ZoneId> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZoneId getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+    	
+        return getZoneId();
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/ZoneOffsetTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/ZoneOffsetTypeManufacturerImpl.java
@@ -1,0 +1,39 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.ZoneOffset;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.api.PodamUtils;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.ZoneOffset} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZoneOffsetTypeManufacturerImpl extends AbstractTypeManufacturer<ZoneOffset> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZoneOffset getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        int seconds = 0;
+        int minutes = 0;
+        int hours = PodamUtils.getIntegerInRange(-17, 17);
+        if(hours < 0) {
+        
+        	minutes = PodamUtils.getIntegerInRange(-59, 0);
+        	seconds = PodamUtils.getIntegerInRange(-59, 0);
+        	
+        } else {
+
+        	minutes = PodamUtils.getIntegerInRange(0, 59);
+        	seconds = PodamUtils.getIntegerInRange(0, 59);
+        }
+
+    	return ZoneOffset.ofHoursMinutesSeconds(hours, minutes, seconds);	
+    }
+}

--- a/src/main/java/uk/co/jemos/podam/typeManufacturers/ZonedDateTimeTypeManufacturerImpl.java
+++ b/src/main/java/uk/co/jemos/podam/typeManufacturers/ZonedDateTimeTypeManufacturerImpl.java
@@ -1,0 +1,33 @@
+package uk.co.jemos.podam.typeManufacturers;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.concurrent.atomic.AtomicReference;
+import uk.co.jemos.podam.api.AttributeMetadata;
+import uk.co.jemos.podam.api.DataProviderStrategy;
+import uk.co.jemos.podam.common.CommonTypeOrStrategy;
+import uk.co.jemos.podam.common.ManufacturingContext;
+
+/**
+ * Default {@link java.time.ZonedDateTime} type manufacturer.
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZonedDateTimeTypeManufacturerImpl extends AbstractTypeManufacturer<ZonedDateTime> implements CommonTypeOrStrategy {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ZonedDateTime getType(DataProviderStrategy strategy, AttributeMetadata attributeMetadata, ManufacturingContext manufacturingCtx) {
+
+        AtomicReference<Long> seconds = new AtomicReference<>();
+        AtomicReference<Long> nanos = new AtomicReference<>();
+
+        getSecondsNanos(attributeMetadata.getAttributeAnnotations(), seconds, nanos);
+
+        Instant instant = Instant.ofEpochSecond(seconds.get(), nanos.get());
+
+        return ZonedDateTime.ofInstant(instant, getZoneId());
+    }
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/ClockValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/ClockValuePojo.java
@@ -1,0 +1,70 @@
+/**
+ * 
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import java.io.Serializable;
+import java.time.Clock;
+
+/**
+ * POJO to test the annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ClockValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private Clock clockFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public Clock getClockFieldValue() {
+		return clockFieldValue;
+	}
+
+	/**
+	 * @param clockFieldValue
+	 *            the clockFieldValue to set
+	 */
+	public void setClockFieldValue(Clock clockFieldValue) {
+		this.clockFieldValue = clockFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("ClockRangeValuesPojo ( ")
+	        	.append("clockFieldValue = ")
+				.append(this.clockFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/DurationValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/DurationValuePojo.java
@@ -1,0 +1,75 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+/**
+ * POJO to test the annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class DurationValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private Duration durationFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public Duration getDurationFieldValue() {
+		return durationFieldValue;
+	}
+
+	/**
+	 * @param durationFieldValue
+	 *            the durationFieldValue to set
+	 */
+	public void setDurationFieldValue(Duration durationFieldValue) {
+		this.durationFieldValue = durationFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("DurationRangeValuesPojo ( ")
+	        	.append("durationFieldValue = ")
+				.append(this.durationFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/InstantValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/InstantValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class InstantValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private Instant instantFieldWithFutureValue;
+
+	@FutureOrPresent
+	private Instant instantFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private Instant instantFieldWithPastOrPresentValue;
+
+	@Past
+	private Instant instantFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public Instant getInstantFieldWithFutureValue() {
+		return instantFieldWithFutureValue;
+	}
+
+	/**
+	 * @param instantFieldWithFutureValue
+	 *            the instantFieldWithFutureValue to set
+	 */
+	public void setInstantFieldWithFutureValue(Instant instantFieldWithFutureValue) {
+		this.instantFieldWithFutureValue = instantFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the instantFieldWithFutureOrPresentValue
+	 */
+	public Instant getInstantFieldWithFutureOrPresentValue() {
+		return instantFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param instantFieldWithFutureOrPresentValue
+	 *            the instantFieldWithFutureOrPresentValue to set
+	 */
+	public void setInstantFieldWithFutureOrPresentValue(Instant instantFieldWithFutureOrPresentValue) {
+		this.instantFieldWithFutureOrPresentValue = instantFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the instantFieldWithPastOrPresentValue
+	 */
+	public Instant getInstantFieldWithPastOrPresentValue() {
+		return instantFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param instantFieldWithPastOrPresentValue
+	 *            the instantFieldWithPastOrPresentValue to set
+	 */
+	public void setInstantFieldWithPastOrPresentValue(
+			Instant instantFieldWithPastOrPresentValue) {
+		this.instantFieldWithPastOrPresentValue = instantFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the instantFieldWithPastValue
+	 */
+	public Instant getInstantFieldWithPastValue() {
+		return instantFieldWithPastValue;
+	}
+
+	/**
+	 * @param instantFieldWithPastValue
+	 *            the instantFieldWithPastValue to set
+	 */
+	public void setInstantFieldWithPastValue(
+			Instant instantFieldWithPastValue) {
+		this.instantFieldWithPastValue = instantFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("InstantRangeValuesPojo ( ")
+	        	.append("instantFieldWithFutureValue = ")
+				.append(this.instantFieldWithFutureValue)
+				.append(TAB)
+	        	.append("instantFieldWithFutureOrPresentValue = ")
+				.append(this.instantFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("instantFieldWithPastOrPresentValue = ")
+				.append(this.instantFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("instantFieldWithPastValue = ")
+				.append(this.instantFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalDateTimeValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalDateTimeValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalDateTimeValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private LocalDateTime localDateTimeFieldWithFutureValue;
+
+	@FutureOrPresent
+	private LocalDateTime localDateTimeFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private LocalDateTime localDateTimeFieldWithPastOrPresentValue;
+
+	@Past
+	private LocalDateTime localDateTimeFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public LocalDateTime getLocalDateTimeFieldWithFutureValue() {
+		return localDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @param localDateTimeFieldWithFutureValue
+	 *            the localDateTimeFieldWithFutureValue to set
+	 */
+	public void setLocalDateTimeFieldWithFutureValue(LocalDateTime localDateTimeFieldWithFutureValue) {
+		this.localDateTimeFieldWithFutureValue = localDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the localDateTimeFieldWithFutureOrPresentValue
+	 */
+	public LocalDateTime getLocalDateTimeFieldWithFutureOrPresentValue() {
+		return localDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param localDateTimeFieldWithFutureOrPresentValue
+	 *            the localDateTimeFieldWithFutureOrPresentValue to set
+	 */
+	public void setLocalDateTimeFieldWithFutureOrPresentValue(LocalDateTime localDateTimeFieldWithFutureOrPresentValue) {
+		this.localDateTimeFieldWithFutureOrPresentValue = localDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the localDateTimeFieldWithPastOrPresentValue
+	 */
+	public LocalDateTime getLocalDateTimeFieldWithPastOrPresentValue() {
+		return localDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param localDateTimeFieldWithPastOrPresentValue
+	 *            the localDateTimeFieldWithPastOrPresentValue to set
+	 */
+	public void setLocalDateTimeFieldWithPastOrPresentValue(
+			LocalDateTime localDateTimeFieldWithPastOrPresentValue) {
+		this.localDateTimeFieldWithPastOrPresentValue = localDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the localDateTimeFieldWithPastValue
+	 */
+	public LocalDateTime getLocalDateTimeFieldWithPastValue() {
+		return localDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * @param localDateTimeFieldWithPastValue
+	 *            the localDateTimeFieldWithPastValue to set
+	 */
+	public void setLocalDateTimeFieldWithPastValue(
+			LocalDateTime localDateTimeFieldWithPastValue) {
+		this.localDateTimeFieldWithPastValue = localDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("LocalDateTimeRangeValuesPojo ( ")
+	        	.append("localDateTimeFieldWithFutureValue = ")
+				.append(this.localDateTimeFieldWithFutureValue)
+				.append(TAB)
+	        	.append("localDateTimeFieldWithFutureOrPresentValue = ")
+				.append(this.localDateTimeFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("localDateTimeFieldWithPastOrPresentValue = ")
+				.append(this.localDateTimeFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("localDateTimeFieldWithPastValue = ")
+				.append(this.localDateTimeFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalDateValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalDateValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalDateValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private LocalDate localDateFieldWithFutureValue;
+
+	@FutureOrPresent
+	private LocalDate localDateFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private LocalDate localDateFieldWithPastOrPresentValue;
+
+	@Past
+	private LocalDate localDateFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public LocalDate getLocalDateFieldWithFutureValue() {
+		return localDateFieldWithFutureValue;
+	}
+
+	/**
+	 * @param localDateFieldWithFutureValue
+	 *            the localDateFieldWithFutureValue to set
+	 */
+	public void setLocalDateFieldWithFutureValue(LocalDate localDateFieldWithFutureValue) {
+		this.localDateFieldWithFutureValue = localDateFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the localDateFieldWithFutureOrPresentValue
+	 */
+	public LocalDate getLocalDateFieldWithFutureOrPresentValue() {
+		return localDateFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param localDateFieldWithFutureOrPresentValue
+	 *            the localDateFieldWithFutureOrPresentValue to set
+	 */
+	public void setLocalDateFieldWithFutureOrPresentValue(LocalDate localDateFieldWithFutureOrPresentValue) {
+		this.localDateFieldWithFutureOrPresentValue = localDateFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the localDateFieldWithPastOrPresentValue
+	 */
+	public LocalDate getLocalDateFieldWithPastOrPresentValue() {
+		return localDateFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param localDateFieldWithPastOrPresentValue
+	 *            the localDateFieldWithPastOrPresentValue to set
+	 */
+	public void setLocalDateFieldWithPastOrPresentValue(
+			LocalDate localDateFieldWithPastOrPresentValue) {
+		this.localDateFieldWithPastOrPresentValue = localDateFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the localDateFieldWithPastValue
+	 */
+	public LocalDate getLocalDateFieldWithPastValue() {
+		return localDateFieldWithPastValue;
+	}
+
+	/**
+	 * @param localDateFieldWithPastValue
+	 *            the localDateFieldWithPastValue to set
+	 */
+	public void setLocalDateFieldWithPastValue(
+			LocalDate localDateFieldWithPastValue) {
+		this.localDateFieldWithPastValue = localDateFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("LocalDateRangeValuesPojo ( ")
+	        	.append("localDateFieldWithFutureValue = ")
+				.append(this.localDateFieldWithFutureValue)
+				.append(TAB)
+	        	.append("localDateFieldWithFutureOrPresentValue = ")
+				.append(this.localDateFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("localDateFieldWithPastOrPresentValue = ")
+				.append(this.localDateFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("localDateFieldWithPastValue = ")
+				.append(this.localDateFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalTimeValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/LocalTimeValuePojo.java
@@ -1,0 +1,78 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.LocalTime;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class LocalTimeValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private LocalTime localTimeFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public LocalTime getLocalTimeFieldValue() {
+		return localTimeFieldValue;
+	}
+
+	/**
+	 * @param localTimeFieldValue
+	 *            the localTimeFieldValue to set
+	 */
+	public void setLocalTimeFieldValue(LocalTime localTimeFieldValue) {
+		this.localTimeFieldValue = localTimeFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("LocalTimeRangeValuesPojo ( ")
+	        	.append("localTimeFieldValue = ")
+				.append(this.localTimeFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/MonthDayValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/MonthDayValuePojo.java
@@ -1,0 +1,78 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.MonthDay;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class MonthDayValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private MonthDay monthDayFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public MonthDay getMonthDayFieldValue() {
+		return monthDayFieldValue;
+	}
+
+	/**
+	 * @param monthDayFieldValue
+	 *            the monthDayFieldValue to set
+	 */
+	public void setMonthDayFieldValue(MonthDay monthDayFieldValue) {
+		this.monthDayFieldValue = monthDayFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("MonthDayRangeValuesPojo ( ")
+	        	.append("monthDayFieldValue = ")
+				.append(this.monthDayFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/OffsetDateTimeValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/OffsetDateTimeValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class OffsetDateTimeValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private OffsetDateTime offsetDateTimeFieldWithFutureValue;
+
+	@FutureOrPresent
+	private OffsetDateTime offsetDateTimeFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private OffsetDateTime offsetDateTimeFieldWithPastOrPresentValue;
+
+	@Past
+	private OffsetDateTime offsetDateTimeFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public OffsetDateTime getOffsetDateTimeFieldWithFutureValue() {
+		return offsetDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @param offsetDateTimeFieldWithFutureValue
+	 *            the offsetDateTimeFieldWithFutureValue to set
+	 */
+	public void setOffsetDateTimeFieldWithFutureValue(OffsetDateTime offsetDateTimeFieldWithFutureValue) {
+		this.offsetDateTimeFieldWithFutureValue = offsetDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the offsetDateTimeFieldWithFutureOrPresentValue
+	 */
+	public OffsetDateTime getOffsetDateTimeFieldWithFutureOrPresentValue() {
+		return offsetDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param offsetDateTimeFieldWithFutureOrPresentValue
+	 *            the offsetDateTimeFieldWithFutureOrPresentValue to set
+	 */
+	public void setOffsetDateTimeFieldWithFutureOrPresentValue(OffsetDateTime offsetDateTimeFieldWithFutureOrPresentValue) {
+		this.offsetDateTimeFieldWithFutureOrPresentValue = offsetDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the offsetDateTimeFieldWithPastOrPresentValue
+	 */
+	public OffsetDateTime getOffsetDateTimeFieldWithPastOrPresentValue() {
+		return offsetDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param offsetDateTimeFieldWithPastOrPresentValue
+	 *            the offsetDateTimeFieldWithPastOrPresentValue to set
+	 */
+	public void setOffsetDateTimeFieldWithPastOrPresentValue(
+			OffsetDateTime offsetDateTimeFieldWithPastOrPresentValue) {
+		this.offsetDateTimeFieldWithPastOrPresentValue = offsetDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the offsetDateTimeFieldWithPastValue
+	 */
+	public OffsetDateTime getOffsetDateTimeFieldWithPastValue() {
+		return offsetDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * @param offsetDateTimeFieldWithPastValue
+	 *            the offsetDateTimeFieldWithPastValue to set
+	 */
+	public void setOffsetDateTimeFieldWithPastValue(
+			OffsetDateTime offsetDateTimeFieldWithPastValue) {
+		this.offsetDateTimeFieldWithPastValue = offsetDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("OffsetDateTimeRangeValuesPojo ( ")
+	        	.append("offsetDateTimeFieldWithFutureValue = ")
+				.append(this.offsetDateTimeFieldWithFutureValue)
+				.append(TAB)
+	        	.append("offsetDateTimeFieldWithFutureOrPresentValue = ")
+				.append(this.offsetDateTimeFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("offsetDateTimeFieldWithPastOrPresentValue = ")
+				.append(this.offsetDateTimeFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("offsetDateTimeFieldWithPastValue = ")
+				.append(this.offsetDateTimeFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/OffsetTimeValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/OffsetTimeValuePojo.java
@@ -1,0 +1,78 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.OffsetTime;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class OffsetTimeValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private OffsetTime offsetTimeFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public OffsetTime getOffsetTimeFieldValue() {
+		return offsetTimeFieldValue;
+	}
+
+	/**
+	 * @param offsetTimeFieldValue
+	 *            the offsetTimeFieldValue to set
+	 */
+	public void setOffsetTimeFieldValue(OffsetTime offsetTimeFieldValue) {
+		this.offsetTimeFieldValue = offsetTimeFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("OffsetTimeRangeValuesPojo ( ")
+	        	.append("offsetTimeFieldValue = ")
+				.append(this.offsetTimeFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/PeriodValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/PeriodValuePojo.java
@@ -1,0 +1,70 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import java.io.Serializable;
+import java.time.Period;
+
+/**
+ * POJO to test the annotations
+ *
+ * @author liam on 04/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class PeriodValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private Period periodFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public Period getPeriodFieldValue() {
+		return periodFieldValue;
+	}
+
+	/**
+	 * @param periodFieldValue
+	 *            the periodFieldValue to set
+	 */
+	public void setPeriodFieldValue(Period periodFieldValue) {
+		this.periodFieldValue = periodFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("PeriodRangeValuesPojo ( ")
+	        	.append("periodFieldValue = ")
+				.append(this.periodFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/YearMonthValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/YearMonthValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.YearMonth;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class YearMonthValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private YearMonth yearMonthFieldWithFutureValue;
+
+	@FutureOrPresent
+	private YearMonth yearMonthFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private YearMonth yearMonthFieldWithPastOrPresentValue;
+
+	@Past
+	private YearMonth yearMonthFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public YearMonth getYearMonthFieldWithFutureValue() {
+		return yearMonthFieldWithFutureValue;
+	}
+
+	/**
+	 * @param yearMonthFieldWithFutureValue
+	 *            the yearMonthFieldWithFutureValue to set
+	 */
+	public void setYearMonthFieldWithFutureValue(YearMonth yearMonthFieldWithFutureValue) {
+		this.yearMonthFieldWithFutureValue = yearMonthFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the yearMonthFieldWithFutureOrPresentValue
+	 */
+	public YearMonth getYearMonthFieldWithFutureOrPresentValue() {
+		return yearMonthFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param yearMonthFieldWithFutureOrPresentValue
+	 *            the yearMonthFieldWithFutureOrPresentValue to set
+	 */
+	public void setYearMonthFieldWithFutureOrPresentValue(YearMonth yearMonthFieldWithFutureOrPresentValue) {
+		this.yearMonthFieldWithFutureOrPresentValue = yearMonthFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the yearMonthFieldWithPastOrPresentValue
+	 */
+	public YearMonth getYearMonthFieldWithPastOrPresentValue() {
+		return yearMonthFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param yearMonthFieldWithPastOrPresentValue
+	 *            the yearMonthFieldWithPastOrPresentValue to set
+	 */
+	public void setYearMonthFieldWithPastOrPresentValue(
+			YearMonth yearMonthFieldWithPastOrPresentValue) {
+		this.yearMonthFieldWithPastOrPresentValue = yearMonthFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the yearMonthFieldWithPastValue
+	 */
+	public YearMonth getYearMonthFieldWithPastValue() {
+		return yearMonthFieldWithPastValue;
+	}
+
+	/**
+	 * @param yearMonthFieldWithPastValue
+	 *            the yearMonthFieldWithPastValue to set
+	 */
+	public void setYearMonthFieldWithPastValue(
+			YearMonth yearMonthFieldWithPastValue) {
+		this.yearMonthFieldWithPastValue = yearMonthFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("YearMonthRangeValuesPojo ( ")
+	        	.append("yearMonthFieldWithFutureValue = ")
+				.append(this.yearMonthFieldWithFutureValue)
+				.append(TAB)
+	        	.append("yearMonthFieldWithFutureOrPresentValue = ")
+				.append(this.yearMonthFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("yearMonthFieldWithPastOrPresentValue = ")
+				.append(this.yearMonthFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("yearMonthFieldWithPastValue = ")
+				.append(this.yearMonthFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/YearValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/YearValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.Year;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 03/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class YearValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private Year yearFieldWithFutureValue;
+
+	@FutureOrPresent
+	private Year yearFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private Year yearFieldWithPastOrPresentValue;
+
+	@Past
+	private Year yearFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public Year getYearFieldWithFutureValue() {
+		return yearFieldWithFutureValue;
+	}
+
+	/**
+	 * @param yearFieldWithFutureValue
+	 *            the yearFieldWithFutureValue to set
+	 */
+	public void setYearFieldWithFutureValue(Year yearFieldWithFutureValue) {
+		this.yearFieldWithFutureValue = yearFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the yearFieldWithFutureOrPresentValue
+	 */
+	public Year getYearFieldWithFutureOrPresentValue() {
+		return yearFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param yearFieldWithFutureOrPresentValue
+	 *            the yearFieldWithFutureOrPresentValue to set
+	 */
+	public void setYearFieldWithFutureOrPresentValue(Year yearFieldWithFutureOrPresentValue) {
+		this.yearFieldWithFutureOrPresentValue = yearFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the yearFieldWithPastOrPresentValue
+	 */
+	public Year getYearFieldWithPastOrPresentValue() {
+		return yearFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param yearFieldWithPastOrPresentValue
+	 *            the yearFieldWithPastOrPresentValue to set
+	 */
+	public void setYearFieldWithPastOrPresentValue(
+			Year yearFieldWithPastOrPresentValue) {
+		this.yearFieldWithPastOrPresentValue = yearFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the yearFieldWithPastValue
+	 */
+	public Year getYearFieldWithPastValue() {
+		return yearFieldWithPastValue;
+	}
+
+	/**
+	 * @param yearFieldWithPastValue
+	 *            the yearFieldWithPastValue to set
+	 */
+	public void setYearFieldWithPastValue(
+			Year yearFieldWithPastValue) {
+		this.yearFieldWithPastValue = yearFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("YearRangeValuesPojo ( ")
+	        	.append("yearFieldWithFutureValue = ")
+				.append(this.yearFieldWithFutureValue)
+				.append(TAB)
+	        	.append("yearFieldWithFutureOrPresentValue = ")
+				.append(this.yearFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("yearFieldWithPastOrPresentValue = ")
+				.append(this.yearFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("yearFieldWithPastValue = ")
+				.append(this.yearFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZoneIdValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZoneIdValuePojo.java
@@ -1,0 +1,78 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.ZoneId;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZoneIdValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private ZoneId zoneIdFieldValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public ZoneId getZoneIdFieldValue() {
+		return zoneIdFieldValue;
+	}
+
+	/**
+	 * @param zoneIdFieldValue
+	 *            the zoneIdFieldValue to set
+	 */
+	public void setZoneIdFieldValue(ZoneId zoneIdFieldValue) {
+		this.zoneIdFieldValue = zoneIdFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("ZoneIdRangeValuesPojo ( ")
+	        	.append("zoneIdFieldValue = ")
+				.append(this.zoneIdFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZoneOffsetValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZoneOffsetValuePojo.java
@@ -1,0 +1,71 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import java.io.Serializable;
+import java.time.ZoneOffset;
+
+/**
+ * POJO to test the annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZoneOffsetValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	private ZoneOffset zoneOffsetFieldValue;
+
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public ZoneOffset getZoneOffsetFieldValue() {
+		return zoneOffsetFieldValue;
+	}
+
+	/**
+	 * @param zoneOffsetFieldValue
+	 *            the zoneOffsetFieldValue to set
+	 */
+	public void setZoneOffsetFieldValue(ZoneOffset zoneOffsetFieldValue) {
+		this.zoneOffsetFieldValue = zoneOffsetFieldValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("ZoneOffsetRangeValuesPojo ( ")
+	        	.append("zoneOffsetFieldValue = ")
+				.append(this.zoneOffsetFieldValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZonedDateTimeValuePojo.java
+++ b/src/test/java/uk/co/jemos/podam/test/dto/issue323/ZonedDateTimeValuePojo.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package uk.co.jemos.podam.test.dto.issue323;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+
+/**
+ * POJO to test the {@link Future},
+ * {@link FutureOrPresent},
+ * {@link PastOrPresent} or
+ * {@link Past} annotations
+ *
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+public class ZonedDateTimeValuePojo implements Serializable {
+
+	// ------------------->> Constants
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------->> Instance / Static variables
+
+	@Future
+	private ZonedDateTime zonedDateTimeFieldWithFutureValue;
+
+	@FutureOrPresent
+	private ZonedDateTime zonedDateTimeFieldWithFutureOrPresentValue;
+
+	@PastOrPresent
+	private ZonedDateTime zonedDateTimeFieldWithPastOrPresentValue;
+
+	@Past
+	private ZonedDateTime zonedDateTimeFieldWithPastValue;
+
+	// ------------------->> Constructors
+
+	// ------------------->> Public methods
+
+	// ------------------->> Getters / Setters
+
+	/**
+	 * @return the floatFieldWithMinValueOnly
+	 */
+	public ZonedDateTime getZonedDateTimeFieldWithFutureValue() {
+		return zonedDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @param zonedDateTimeFieldWithFutureValue
+	 *            the zonedDateTimeFieldWithFutureValue to set
+	 */
+	public void setZonedDateTimeFieldWithFutureValue(ZonedDateTime zonedDateTimeFieldWithFutureValue) {
+		this.zonedDateTimeFieldWithFutureValue = zonedDateTimeFieldWithFutureValue;
+	}
+
+	/**
+	 * @return the zonedDateTimeFieldWithFutureOrPresentValue
+	 */
+	public ZonedDateTime getZonedDateTimeFieldWithFutureOrPresentValue() {
+		return zonedDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @param zonedDateTimeFieldWithFutureOrPresentValue
+	 *            the zonedDateTimeFieldWithFutureOrPresentValue to set
+	 */
+	public void setZonedDateTimeFieldWithFutureOrPresentValue(ZonedDateTime zonedDateTimeFieldWithFutureOrPresentValue) {
+		this.zonedDateTimeFieldWithFutureOrPresentValue = zonedDateTimeFieldWithFutureOrPresentValue;
+	}
+
+	/**
+	 * @return the zonedDateTimeFieldWithPastOrPresentValue
+	 */
+	public ZonedDateTime getZonedDateTimeFieldWithPastOrPresentValue() {
+		return zonedDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @param zonedDateTimeFieldWithPastOrPresentValue
+	 *            the zonedDateTimeFieldWithPastOrPresentValue to set
+	 */
+	public void setZonedDateTimeFieldWithPastOrPresentValue(
+			ZonedDateTime zonedDateTimeFieldWithPastOrPresentValue) {
+		this.zonedDateTimeFieldWithPastOrPresentValue = zonedDateTimeFieldWithPastOrPresentValue;
+	}
+
+	/**
+	 * @return the zonedDateTimeFieldWithPastValue
+	 */
+	public ZonedDateTime getZonedDateTimeFieldWithPastValue() {
+		return zonedDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * @param zonedDateTimeFieldWithPastValue
+	 *            the zonedDateTimeFieldWithPastValue to set
+	 */
+	public void setZonedDateTimeFieldWithPastValue(
+			ZonedDateTime zonedDateTimeFieldWithPastValue) {
+		this.zonedDateTimeFieldWithPastValue = zonedDateTimeFieldWithPastValue;
+	}
+
+	/**
+	 * Constructs a <code>String</code> with all attributes
+	 * in name = value format.
+	 *
+	 * @return a <code>String</code> representation 
+	 * of this object.
+	 */
+	public String toString()
+	{
+	    final String TAB = "    ";
+	
+	    return new StringBuilder().append("ZonedDateTimeRangeValuesPojo ( ")
+	        	.append("zonedDateTimeFieldWithFutureValue = ")
+				.append(this.zonedDateTimeFieldWithFutureValue)
+				.append(TAB)
+	        	.append("zonedDateTimeFieldWithFutureOrPresentValue = ")
+				.append(this.zonedDateTimeFieldWithFutureOrPresentValue)
+				.append(TAB)
+	        	.append("zonedDateTimeFieldWithPastOrPresentValue = ")
+				.append(this.zonedDateTimeFieldWithPastOrPresentValue)
+				.append(TAB)
+	        	.append("zonedDateTimeFieldWithPastValue = ")
+				.append(this.zonedDateTimeFieldWithPastValue)
+				.append(TAB)
+	        	.append(" )")
+	    		.toString();
+	}
+
+	// ------------------->> Private methods
+
+	// ------------------->> equals() / hashcode() / toString()
+
+	// ------------------->> Inner classes
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/issue323/AnnotationsTest.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/issue323/AnnotationsTest.java
@@ -1,0 +1,378 @@
+package uk.co.jemos.podam.test.unit.issue323;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.thucydides.core.annotations.Title;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.test.dto.issue323.*;
+import uk.co.jemos.podam.test.unit.AbstractPodamSteps;
+import uk.co.jemos.podam.test.dto.issue323.ClockValuePojo;
+import uk.co.jemos.podam.test.dto.issue323.DurationValuePojo;
+
+/**
+ * @author liam on 02/01/2024.
+ * @since 8.0.1.RELEASE
+ */
+@RunWith(SerenityRunner.class)
+public class AnnotationsTest extends AbstractPodamSteps {
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Clock} values")
+    public void podamShouldHandleClockFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ClockValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ClockValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getClockFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Duration} values")
+    public void podamShouldHandleDurationAnnotated() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        DurationValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(DurationValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getDurationFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Instant} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleInstantAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        InstantValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(InstantValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theInstantShouldInTheFutur(pojo.getInstantFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Instant} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleInstantAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        InstantValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(InstantValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theInstantShouldInTheFuturOrPresent(pojo.getInstantFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Instant} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleInstantAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        InstantValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(InstantValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theInstantShouldInThePastOrPresent(pojo.getInstantFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Instant} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleInstantAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        InstantValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(InstantValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theInstantShouldInThePast(pojo.getInstantFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDateTime} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleLocalDateTimeAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateTimeShouldInTheFutur(pojo.getLocalDateTimeFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDateTime} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleLocalDateTimeAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateTimeShouldInTheFuturOrPresent(pojo.getLocalDateTimeFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDateTime} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleLocalDateTimeAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateTimeShouldInThePastOrPresent(pojo.getLocalDateTimeFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDateTime} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleLocalDateTimeAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateTimeShouldInThePast(pojo.getLocalDateTimeFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDate} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleLocalDateAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateShouldInTheFutur(pojo.getLocalDateFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDate} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleLocalDateAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateShouldInTheFuturOrPresent(pojo.getLocalDateFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDate} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleLocalDateAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateShouldInThePastOrPresent(pojo.getLocalDateFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalDate} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleLocalDateAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalDateValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalDateValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theLocalDateShouldInThePast(pojo.getLocalDateFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.LocalTime} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleLocalTimeAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        LocalTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(LocalTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getLocalTimeFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.OffsetDateTime} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleOffsetDateTimeAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        OffsetDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(OffsetDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theOffsetDateTimeShouldInTheFutur(pojo.getOffsetDateTimeFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.OffsetDateTime} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleOffsetDateTimeAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        OffsetDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(OffsetDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theOffsetDateTimeShouldInTheFuturOrPresent(pojo.getOffsetDateTimeFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.OffsetDateTime} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleOffsetDateTimeAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        OffsetDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(OffsetDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theOffsetDateTimeShouldInThePastOrPresent(pojo.getOffsetDateTimeFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.OffsetDateTime} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleOffsetDateTimeAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        OffsetDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(OffsetDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theOffsetDateTimeShouldInThePast(pojo.getOffsetDateTimeFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.MonthDay} values")
+    public void podamShouldHandleMonthDayAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        MonthDayValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(MonthDayValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getMonthDayFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.OffsetTime} values")
+    public void podamShouldHandleOffsetTimeAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        OffsetTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(OffsetTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getOffsetTimeFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Period} values")
+    public void podamShouldHandlePeriodAnnotated() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        PeriodValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(PeriodValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getPeriodFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.YearMonth} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleYearMonthAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearMonthValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearMonthValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearMonthShouldInTheFutur(pojo.getYearMonthFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.YearMonth} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleYearMonthAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearMonthValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearMonthValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearMonthShouldInTheFuturOrPresent(pojo.getYearMonthFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.YearMonth} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleYearMonthAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearMonthValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearMonthValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearMonthShouldInThePastOrPresent(pojo.getYearMonthFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.YearMonth} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleYearMonthAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearMonthValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearMonthValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearMonthShouldInThePast(pojo.getYearMonthFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Year} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleYearAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearShouldInTheFutur(pojo.getYearFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Year} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleYearAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearShouldInTheFuturOrPresent(pojo.getYearFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Year} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleYearAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearShouldInThePastOrPresent(pojo.getYearFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.Year} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleYearAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        YearValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(YearValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theYearShouldInThePast(pojo.getYearFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZonedDateTime} values with {@link jakarta.validation.constraint.Future} annotation")
+    public void podamShouldHandleZonedDateTimeAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZonedDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZonedDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theZonedDateTimeShouldInTheFutur(pojo.getZonedDateTimeFieldWithFutureValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZonedDateTime} values with {@link jakarta.validation.constraint.FutureOrPresent} annotation")
+    public void podamShouldHandleZonedDateTimeAnnotatedWithFutureOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZonedDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZonedDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theZonedDateTimeShouldInTheFuturOrPresent(pojo.getZonedDateTimeFieldWithFutureOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZonedDateTime} values with {@link jakarta.validation.constraint.PastOrPresent} annotation")
+    public void podamShouldHandleZonedDateTimeAnnotatedWithPastOrPresent() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZonedDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZonedDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theZonedDateTimeShouldInThePastOrPresent(pojo.getZonedDateTimeFieldWithPastOrPresentValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZonedDateTime} values with {@link jakarta.validation.constraint.Past} annotation")
+    public void podamShouldHandleZonedDateTimeAnnotatedWithPast() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZonedDateTimeValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZonedDateTimeValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theZonedDateTimeShouldInThePast(pojo.getZonedDateTimeFieldWithPastValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZoneId} values")
+    public void podamShouldHandleZoneIdAnnotated() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZoneIdValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZoneIdValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getZoneIdFieldValue());
+    }
+
+    @Test
+    @Title("Podam should handle both native and wrapped {@link java.time.ZoneOffset} values")
+    public void podamShouldHandleZoneOffsetAnnotatedWithFuture() throws Exception {
+
+        PodamFactory podamFactory = podamFactorySteps.givenAStandardPodamFactory();
+        ZoneOffsetValuePojo pojo = podamInvocationSteps.whenIInvokeTheFactoryForClass(ZoneOffsetValuePojo.class, podamFactory);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo);
+        podamValidationSteps.theObjectShouldNotBeNull(pojo.getZoneOffsetFieldValue());
+    }
+}

--- a/src/test/java/uk/co/jemos/podam/test/unit/issue323/package-info.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/issue323/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Contains stories for Podam annotations.
+ *
+ * Created by tedonema on 31/05/2015.
+ *
+ * @since 5.5.0
+ */
+package uk.co.jemos.podam.test.unit.issue323;

--- a/src/test/java/uk/co/jemos/podam/test/unit/steps/PodamValidationSteps.java
+++ b/src/test/java/uk/co/jemos/podam/test/unit/steps/PodamValidationSteps.java
@@ -7,6 +7,7 @@ import uk.co.jemos.podam.api.DataProviderStrategy;
 import uk.co.jemos.podam.test.utils.TypesUtils;
 
 import java.lang.reflect.Array;
+import java.time.*;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -375,5 +376,191 @@ public class PodamValidationSteps {
     public void theMemoizationShouldBeEnabled(DataProviderStrategy strategy, boolean isMemoizationEnabled) {
 
         Assert.assertEquals("Payload must be valid", isMemoizationEnabled, strategy.isMemoizationEnabled());
+    }
+
+    @Step("Then {@java.time.Instant} should be in the futur")
+    public void theInstantShouldInTheFutur(Instant pojo) {
+        Assert.assertNotNull("The {@java.time.Instant} should not be null", pojo);
+        assertThat("The {@java.time.Instant} should be in the futur", pojo.isAfter(Instant.now()));
+    }
+
+    @Step("Then {@java.time.Instant} should be in the futur or present")
+    public void theInstantShouldInTheFuturOrPresent(Instant pojo) {
+        Assert.assertNotNull("The {@java.time.Instant} should not be null", pojo);
+        assertThat("The {@java.time.Instant} should be in the futur or present", pojo.isAfter(Instant.now()));
+    }
+
+    @Step("Then {@java.time.Instant} should be in the past or present")
+    public void theInstantShouldInThePastOrPresent(Instant pojo) {
+        Assert.assertNotNull("The {@java.time.Instant} should not be null", pojo);
+        assertThat("The {@java.time.Instant} should be in the past or present", pojo.isBefore(Instant.now()));
+    }
+
+    @Step("Then {@java.time.Instant} should be in the past")
+    public void theInstantShouldInThePast(Instant pojo) {
+        Assert.assertNotNull("The {@java.time.Instant} should not be null", pojo);
+        assertThat("The {@java.time.Instant} should be in the past", pojo.isBefore(Instant.now()));
+    }
+
+    @Step("Then {@java.time.LocalDateTime} should be in the futur")
+    public void theLocalDateTimeShouldInTheFutur(LocalDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDateTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalDateTime} should be in the futur", pojo.isAfter(LocalDateTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalDateTime} should be in the futur or present")
+    public void theLocalDateTimeShouldInTheFuturOrPresent(LocalDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDateTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalDateTime} should be in the futur or present", pojo.isAfter(LocalDateTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalDateTime} should be in the past or present")
+    public void theLocalDateTimeShouldInThePastOrPresent(LocalDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDateTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalDateTime} should be in the past or present", pojo.isBefore(LocalDateTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalDateTime} should be in the past")
+    public void theLocalDateTimeShouldInThePast(LocalDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDateTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalDateTime} should be in the past", pojo.isBefore(LocalDateTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalDate} should be in the futur")
+    public void theLocalDateShouldInTheFutur(LocalDate pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDate} should not be null", pojo);
+        assertThat("The {@java.time.LocalDate} should be in the futur", pojo.isAfter(LocalDate.now()));
+    }
+
+    @Step("Then {@java.time.LocalDate} should be in the futur or present")
+    public void theLocalDateShouldInTheFuturOrPresent(LocalDate pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDate} should not be null", pojo);
+        assertThat("The {@java.time.LocalDate} should be in the futur or present", pojo.isAfter(LocalDate.now()));
+    }
+
+    @Step("Then {@java.time.LocalDate} should be in the past or present")
+    public void theLocalDateShouldInThePastOrPresent(LocalDate pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDate} should not be null", pojo);
+        assertThat("The {@java.time.LocalDate} should be in the past or present", pojo.isBefore(LocalDate.now()));
+    }
+
+    @Step("Then {@java.time.LocalDate} should be in the past")
+    public void theLocalDateShouldInThePast(LocalDate pojo) {
+        Assert.assertNotNull("The {@java.time.LocalDate} should not be null", pojo);
+        assertThat("The {@java.time.LocalDate} should be in the past", pojo.isBefore(LocalDate.now()));
+    }
+
+    @Step("Then {@java.time.LocalTime} should be in the futur or present")
+    public void theLocalTimeShouldInTheFuturOrPresent(LocalTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalTime} should be in the futur or present", pojo.isAfter(LocalTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalTime} should be in the past or present")
+    public void theLocalTimeShouldInThePastOrPresent(LocalTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalTime} should be in the past or present", pojo.isBefore(LocalTime.now()));
+    }
+
+    @Step("Then {@java.time.LocalTime} should be in the past")
+    public void theLocalTimeShouldInThePast(LocalTime pojo) {
+        Assert.assertNotNull("The {@java.time.LocalTime} should not be null", pojo);
+        assertThat("The {@java.time.LocalTime} should be in the past", pojo.isBefore(LocalTime.now()));
+    }
+
+    @Step("Then {@java.time.OffsetDateTime} should be in the futur")
+    public void theOffsetDateTimeShouldInTheFutur(OffsetDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.OffsetDateTime} should not be null", pojo);
+        assertThat("The {@java.time.OffsetDateTime} should be in the futur", pojo.isAfter(OffsetDateTime.now()));
+    }
+
+    @Step("Then {@java.time.OffsetDateTime} should be in the futur or present")
+    public void theOffsetDateTimeShouldInTheFuturOrPresent(OffsetDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.OffsetDateTime} should not be null", pojo);
+        assertThat("The {@java.time.OffsetDateTime} should be in the futur or present", pojo.isAfter(OffsetDateTime.now()));
+    }
+
+    @Step("Then {@java.time.OffsetDateTime} should be in the past or present")
+    public void theOffsetDateTimeShouldInThePastOrPresent(OffsetDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.OffsetDateTime} should not be null", pojo);
+        assertThat("The {@java.time.OffsetDateTime} should be in the past or present", pojo.isBefore(OffsetDateTime.now()));
+    }
+
+    @Step("Then {@java.time.OffsetDateTime} should be in the past")
+    public void theOffsetDateTimeShouldInThePast(OffsetDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.OffsetDateTime} should not be null", pojo);
+        assertThat("The {@java.time.OffsetDateTime} should be in the past", pojo.isBefore(OffsetDateTime.now()));
+    }
+
+    @Step("Then {@java.time.YearMonth} should be in the futur")
+    public void theYearMonthShouldInTheFutur(YearMonth pojo) {
+        Assert.assertNotNull("The {@java.time.YearMonth} should not be null", pojo);
+        assertThat("The {@java.time.YearMonth} should be in the futur", pojo.isAfter(YearMonth.now()));
+    }
+
+    @Step("Then {@java.time.YearMonth} should be in the futur or present")
+    public void theYearMonthShouldInTheFuturOrPresent(YearMonth pojo) {
+        Assert.assertNotNull("The {@java.time.YearMonth} should not be null", pojo);
+        assertThat("The {@java.time.YearMonth} should be in the futur or present", pojo.isAfter(YearMonth.now()));
+    }
+
+    @Step("Then {@java.time.YearMonth} should be in the past or present")
+    public void theYearMonthShouldInThePastOrPresent(YearMonth pojo) {
+        Assert.assertNotNull("The {@java.time.YearMonth} should not be null", pojo);
+        assertThat("The {@java.time.YearMonth} should be in the past or present", pojo.isBefore(YearMonth.now()));
+    }
+
+    @Step("Then {@java.time.YearMonth} should be in the past")
+    public void theYearMonthShouldInThePast(YearMonth pojo) {
+        Assert.assertNotNull("The {@java.time.YearMonth} should not be null", pojo);
+        assertThat("The {@java.time.YearMonth} should be in the past", pojo.isBefore(YearMonth.now()));
+    }
+
+    @Step("Then {@java.time.Year} should be in the futur")
+    public void theYearShouldInTheFutur(Year pojo) {
+        Assert.assertNotNull("The {@java.time.Year} should not be null", pojo);
+        assertThat("The {@java.time.Year} should be in the futur", pojo.isAfter(Year.now()));
+    }
+
+    @Step("Then {@java.time.Year} should be in the futur or present")
+    public void theYearShouldInTheFuturOrPresent(Year pojo) {
+        Assert.assertNotNull("The {@java.time.Year} should not be null", pojo);
+        assertThat("The {@java.time.Year} should be in the futur or present", pojo.isAfter(Year.now()));
+    }
+
+    @Step("Then {@java.time.Year} should be in the past or present")
+    public void theYearShouldInThePastOrPresent(Year pojo) {
+        Assert.assertNotNull("The {@java.time.Year} should not be null", pojo);
+        assertThat("The {@java.time.Year} should be in the past or present", pojo.isBefore(Year.now()));
+    }
+
+    @Step("Then {@java.time.Year} should be in the past")
+    public void theYearShouldInThePast(Year pojo) {
+        Assert.assertNotNull("The {@java.time.Year} should not be null", pojo);
+        assertThat("The {@java.time.Year} should be in the past", pojo.isBefore(Year.now()));
+    }
+
+    @Step("Then {@java.time.ZonedDateTime} should be in the futur")
+    public void theZonedDateTimeShouldInTheFutur(ZonedDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.ZonedDateTime} should not be null", pojo);
+        assertThat("The {@java.time.ZonedDateTime} should be in the futur", pojo.isAfter(ZonedDateTime.now()));
+    }
+
+    @Step("Then {@java.time.ZonedDateTime} should be in the futur or present")
+    public void theZonedDateTimeShouldInTheFuturOrPresent(ZonedDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.ZonedDateTime} should not be null", pojo);
+        assertThat("The {@java.time.ZonedDateTime} should be in the futur or present", pojo.isAfter(ZonedDateTime.now()));
+    }
+
+    @Step("Then {@java.time.ZonedDateTime} should be in the past or present")
+    public void theZonedDateTimeShouldInThePastOrPresent(ZonedDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.ZonedDateTime} should not be null", pojo);
+        assertThat("The {@java.time.ZonedDateTime} should be in the past or present", pojo.isBefore(ZonedDateTime.now()));
+    }
+
+    @Step("Then {@java.time.ZonedDateTime} should be in the past")
+    public void theZonedDateTimeShouldInThePast(ZonedDateTime pojo) {
+        Assert.assertNotNull("The {@java.time.ZonedDateTime} should not be null", pojo);
+        assertThat("The {@java.time.ZonedDateTime} should be in the past", pojo.isBefore(ZonedDateTime.now()));
     }
 }


### PR DESCRIPTION
I had support of type:
- Clock*
- Duration*
- Instant
- LocalDateTime
- LocalDate
- LocalTime
- MonthDay
- OffsetDateTime
- OffsetTime
- Period*
- YearMonth
- Year
- ZonedDateTime
- ZoneId*
- ZoneOffset*

(*) mean it was not a Temporal instance

For Clock and ZoneId, an annotation allow to force a specific zoneId for test.
All Temporal class appear in 4 news strategy for Future, FuturOrPresent, PastOrPresent and Past annotation.
Notion of Past mean more than 6 months' old, futur more than 6 months in the futur.

Regards
